### PR TITLE
fix: update/delete should not fail when table has multi-column primary key

### DIFF
--- a/test/files/multikey_table_delete.csv
+++ b/test/files/multikey_table_delete.csv
@@ -1,0 +1,3 @@
+id1,id2,text,_fivetran_deleted,_fivetran_synced
+1,100,"does not matter",true,"2024-01-09T04:23:41.165531936Z"
+3,300,"this value does not matter, and neither does _fivetran_deleted -- the row will still be hard deleted because it's in this file",false,"2024-01-09T04:23:41.165531936Z"

--- a/test/files/multikey_table_update.csv
+++ b/test/files/multikey_table_update.csv
@@ -1,0 +1,3 @@
+id1,id2,text,_fivetran_deleted,_fivetran_synced
+2,200,"second row updated",false,"2024-02-09T00:00:00.000000000Z"
+3,300,"third row soft deleted - but also this value updated",true,"2024-02-09T00:00:00.000000000Z"

--- a/test/files/multikey_table_upsert.csv
+++ b/test/files/multikey_table_upsert.csv
@@ -1,0 +1,4 @@
+id1,id2,text,_fivetran_deleted,_fivetran_synced
+1,100,"first row",false,"2024-01-09T04:10:19.156057706Z"
+2,200,"second row",false,"2024-01-09T04:10:19.156057706Z"
+3,300,"third row",false,"2024-01-09T04:10:19.156057706Z"


### PR DESCRIPTION
Joining multiple column clauses in WHERE columns should be done with an " AND ", not with ", ". 

Fixes #31 