### PR TITLE
Upgrade protos to Fivetran SDK v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,9 @@ get_duckdb:
 
 get_fivetran_protos:
 	mkdir -p protos
-	curl -o protos/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/production/destination_sdk.proto
-	curl -o protos/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/production/common.proto
+	# TBD: might need to update to `production` before merging
+	curl -o protos/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/destination_sdk.proto
+	curl -o protos/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/common.proto
 
 build_dependencies: get_duckdb build_openssl_native build_grpc build_arrow build_test_dependencies
 

--- a/includes/fivetran_duckdb_interop.hpp
+++ b/includes/fivetran_duckdb_interop.hpp
@@ -1,8 +1,8 @@
 #include "destination_sdk.grpc.pb.h"
 #include "duckdb.hpp"
 
-fivetran_sdk::DataType
+fivetran_sdk::v2::DataType
 get_fivetran_type(const duckdb::LogicalTypeId &duckdb_type);
 
 duckdb::LogicalTypeId
-get_duckdb_type(const fivetran_sdk::DataType &fivetranType);
+get_duckdb_type(const fivetran_sdk::v2::DataType &fivetranType);

--- a/includes/motherduck_destination_server.hpp
+++ b/includes/motherduck_destination_server.hpp
@@ -19,34 +19,34 @@ static constexpr const int DUCKDB_DEFAULT_PRECISION = 18;
 
 static constexpr const int DUCKDB_DEFAULT_SCALE = 3;
 
-class DestinationSdkImpl final : public fivetran_sdk::Destination::Service {
+class DestinationSdkImpl final : public fivetran_sdk::v2::DestinationConnector::Service {
 public:
   DestinationSdkImpl() = default;
   ~DestinationSdkImpl() = default;
   ::grpc::Status ConfigurationForm(
       ::grpc::ServerContext *context,
-      const ::fivetran_sdk::ConfigurationFormRequest *request,
-      ::fivetran_sdk::ConfigurationFormResponse *response) override;
+      const ::fivetran_sdk::v2::ConfigurationFormRequest *request,
+      ::fivetran_sdk::v2::ConfigurationFormResponse *response) override;
   ::grpc::Status Test(::grpc::ServerContext *context,
-                      const ::fivetran_sdk::TestRequest *request,
-                      ::fivetran_sdk::TestResponse *response) override;
+                      const ::fivetran_sdk::v2::TestRequest *request,
+                      ::fivetran_sdk::v2::TestResponse *response) override;
   ::grpc::Status
   DescribeTable(::grpc::ServerContext *context,
-                const ::fivetran_sdk::DescribeTableRequest *request,
-                ::fivetran_sdk::DescribeTableResponse *response) override;
+                const ::fivetran_sdk::v2::DescribeTableRequest *request,
+                ::fivetran_sdk::v2::DescribeTableResponse *response) override;
   ::grpc::Status
   CreateTable(::grpc::ServerContext *context,
-              const ::fivetran_sdk::CreateTableRequest *request,
-              ::fivetran_sdk::CreateTableResponse *response) override;
+              const ::fivetran_sdk::v2::CreateTableRequest *request,
+              ::fivetran_sdk::v2::CreateTableResponse *response) override;
   ::grpc::Status
   AlterTable(::grpc::ServerContext *context,
-             const ::fivetran_sdk::AlterTableRequest *request,
-             ::fivetran_sdk::AlterTableResponse *response) override;
+             const ::fivetran_sdk::v2::AlterTableRequest *request,
+             ::fivetran_sdk::v2::AlterTableResponse *response) override;
   ::grpc::Status Truncate(::grpc::ServerContext *context,
-                          const ::fivetran_sdk::TruncateRequest *request,
-                          ::fivetran_sdk::TruncateResponse *response) override;
+                          const ::fivetran_sdk::v2::TruncateRequest *request,
+                          ::fivetran_sdk::v2::TruncateResponse *response) override;
   ::grpc::Status
   WriteBatch(::grpc::ServerContext *context,
-             const ::fivetran_sdk::WriteBatchRequest *request,
-             ::fivetran_sdk::WriteBatchResponse *response) override;
+             const ::fivetran_sdk::v2::WriteBatchRequest *request,
+             ::fivetran_sdk::v2::WriteBatchResponse *response) override;
 };

--- a/src/fivetran_duckdb_interop.cpp
+++ b/src/fivetran_duckdb_interop.cpp
@@ -2,65 +2,65 @@
 
 using duckdb::LogicalTypeId;
 
-fivetran_sdk::DataType get_fivetran_type(const LogicalTypeId &duckdb_type) {
+fivetran_sdk::v2::DataType get_fivetran_type(const LogicalTypeId &duckdb_type) {
   switch (duckdb_type) {
   case LogicalTypeId::BOOLEAN:
-    return fivetran_sdk::BOOLEAN;
+    return fivetran_sdk::v2::BOOLEAN;
   case LogicalTypeId::SMALLINT:
-    return fivetran_sdk::SHORT;
+    return fivetran_sdk::v2::SHORT;
   case LogicalTypeId::INTEGER:
-    return fivetran_sdk::INT;
+    return fivetran_sdk::v2::INT;
   case LogicalTypeId::BIGINT:
-    return fivetran_sdk::LONG;
+    return fivetran_sdk::v2::LONG;
   case LogicalTypeId::FLOAT:
-    return fivetran_sdk::FLOAT;
+    return fivetran_sdk::v2::FLOAT;
   case LogicalTypeId::DOUBLE:
-    return fivetran_sdk::DOUBLE;
+    return fivetran_sdk::v2::DOUBLE;
   case LogicalTypeId::DATE:
-    return fivetran_sdk::NAIVE_DATE;
+    return fivetran_sdk::v2::NAIVE_DATE;
   case LogicalTypeId::TIMESTAMP:
-    return fivetran_sdk::NAIVE_DATETIME;
+    return fivetran_sdk::v2::NAIVE_DATETIME;
   case LogicalTypeId::TIMESTAMP_TZ:
-    return fivetran_sdk::UTC_DATETIME;
+    return fivetran_sdk::v2::UTC_DATETIME;
   case LogicalTypeId::DECIMAL:
-    return fivetran_sdk::DECIMAL;
+    return fivetran_sdk::v2::DECIMAL;
   case LogicalTypeId::BIT:
-    return fivetran_sdk::BINARY;
+    return fivetran_sdk::v2::BINARY;
   case LogicalTypeId::VARCHAR:
-    return fivetran_sdk::STRING;
+    return fivetran_sdk::v2::STRING;
   default:
-    return fivetran_sdk::UNSPECIFIED;
+    return fivetran_sdk::v2::UNSPECIFIED;
   }
 }
 
-LogicalTypeId get_duckdb_type(const fivetran_sdk::DataType &fivetranType) {
+LogicalTypeId get_duckdb_type(const fivetran_sdk::v2::DataType &fivetranType) {
   switch (fivetranType) {
-  case fivetran_sdk::BOOLEAN:
+  case fivetran_sdk::v2::BOOLEAN:
     return LogicalTypeId::BOOLEAN;
-  case fivetran_sdk::SHORT:
+  case fivetran_sdk::v2::SHORT:
     return LogicalTypeId::SMALLINT;
-  case fivetran_sdk::INT:
+  case fivetran_sdk::v2::INT:
     return LogicalTypeId::INTEGER;
-  case fivetran_sdk::LONG:
+  case fivetran_sdk::v2::LONG:
     return LogicalTypeId::BIGINT;
-  case fivetran_sdk::FLOAT:
+  case fivetran_sdk::v2::FLOAT:
     return LogicalTypeId::FLOAT;
-  case fivetran_sdk::DOUBLE:
+  case fivetran_sdk::v2::DOUBLE:
     return LogicalTypeId::DOUBLE;
-  case fivetran_sdk::NAIVE_DATE:
+  case fivetran_sdk::v2::NAIVE_DATE:
     return LogicalTypeId::DATE;
-  case fivetran_sdk::NAIVE_DATETIME:
+  case fivetran_sdk::v2::NAIVE_DATETIME:
     return LogicalTypeId::TIMESTAMP;
-  case fivetran_sdk::UTC_DATETIME:
+  case fivetran_sdk::v2::UTC_DATETIME:
     return LogicalTypeId::TIMESTAMP_TZ; // TODO: find format Fivetran sends;
                                         // make sure UTC included
-  case fivetran_sdk::DECIMAL:
+  case fivetran_sdk::v2::DECIMAL:
     return LogicalTypeId::DECIMAL;
-  case fivetran_sdk::BINARY:
+  case fivetran_sdk::v2::BINARY:
     return LogicalTypeId::BIT;
-  case fivetran_sdk::STRING:
+  case fivetran_sdk::v2::STRING:
     return LogicalTypeId::VARCHAR;
-  case fivetran_sdk::JSON:
+  case fivetran_sdk::v2::JSON:
     return LogicalTypeId::
         VARCHAR; // https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/22
   default:


### PR DESCRIPTION
Fivetran is upgrading the SDK framework to v2. This PR incorporates the proto changes. I am going to branch the current `main` into a `v1` branch in case we need to patch the old version, and merge this PR into the main branch, so main will be v2.

old protos:
https://raw.githubusercontent.com/fivetran/fivetran_sdk/production/destination_sdk.proto
https://raw.githubusercontent.com/fivetran/fivetran_sdk/production/common.proto

new protos:
https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/destination_sdk.proto
https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/common.proto