### PR TITLE
Add a nightly integration test run

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    - cron: "15 3 * * *" # run nightly at 3:15am
 
 jobs:
 


### PR DESCRIPTION
1) To keep the dependencies cache filled -- otherwise cache entries go away after (a week?)
2) To find out when non-code environment breaks -- for example, when the CI token expires