### PR TITLE
Columns should never be dropped at destination

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -97,7 +97,6 @@ private:
   alter_table_in_place(duckdb::Connection &con,
                        const std::string &absolute_table_name,
                        const std::set<std::string> &added_columns,
-                       const std::set<std::string> &deleted_columns,
                        const std::set<std::string> &alter_types,
                        const std::map<std::string, column_def> &new_column_map);
 };

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -96,7 +96,7 @@ private:
   void
   alter_table_in_place(duckdb::Connection &con,
                        const std::string &absolute_table_name,
-                       const std::set<std::string> &added_columns,
+                       const std::vector<column_def> &added_columns,
                        const std::set<std::string> &alter_types,
                        const std::map<std::string, column_def> &new_column_map);
 };

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -45,7 +45,7 @@ public:
                                          const table_def &table);
 
   void alter_table(duckdb::Connection &con, const table_def &table,
-                   const std::vector<column_def> &columns);
+                   const std::vector<column_def> &requested_columns);
 
   void upsert(duckdb::Connection &con, const table_def &table,
               const std::string &staging_table_name,

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -355,9 +355,9 @@ void MdSqlGenerator::alter_table_in_place(
   }
 }
 
-void MdSqlGenerator::alter_table(duckdb::Connection &con,
-                                 const table_def &table,
-                                 const std::vector<column_def> &columns) {
+void MdSqlGenerator::alter_table(
+    duckdb::Connection &con, const table_def &table,
+    const std::vector<column_def> &requested_columns) {
 
   bool recreate_table = false;
 
@@ -370,7 +370,7 @@ void MdSqlGenerator::alter_table(duckdb::Connection &con,
   std::map<std::string, column_def> new_column_map;
 
   // start by assuming all columns are new
-  for (const auto &col : columns) {
+  for (const auto &col : requested_columns) {
     new_column_map.emplace(col.name, col);
     added_columns.emplace(col.name);
   }
@@ -423,8 +423,9 @@ void MdSqlGenerator::alter_table(duckdb::Connection &con,
       }
     }
 
-    // add new columns to the end of the column list in order
-    for (const auto &col : columns) {
+    // add new columns to the end of the table, in order they appear in the
+    // request
+    for (const auto &col : requested_columns) {
       const auto &new_col_it = added_columns.find(col.name);
       if (new_col_it != added_columns.end()) {
         all_columns.push_back(new_column_map[col.name]);

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -1430,7 +1430,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
   }
 
   {
-    // Alter Table to drop a primary key column
+    // Alter Table to drop a primary key column -- should be a no-op as dropping columns is not allowed
     ::fivetran_sdk::v2::AlterTableRequest request;
 
     add_config(request, token, TEST_DATABASE_NAME, table_name);
@@ -1456,7 +1456,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
     REQUIRE(!response.not_found());
 
     REQUIRE(response.table().name() == table_name);
-    REQUIRE(response.table().columns_size() == 2);
+    REQUIRE(response.table().columns_size() == 3);
     REQUIRE(response.table().columns(0).name() == "id");
     REQUIRE(response.table().columns(0).type() ==
             ::fivetran_sdk::v2::DataType::STRING);
@@ -1466,6 +1466,11 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
     REQUIRE(response.table().columns(1).type() ==
             ::fivetran_sdk::v2::DataType::STRING);
     REQUIRE(response.table().columns(1).primary_key());
+
+		REQUIRE(response.table().columns(2).name() == "id_new");
+		REQUIRE(response.table().columns(2).type() ==
+						::fivetran_sdk::v2::DataType::INT);
+		REQUIRE(response.table().columns(2).primary_key());
   }
 
   {


### PR DESCRIPTION
At some point the requirement to not drop columns [got formalized](https://github.com/fivetran/fivetran_partner_sdk/pull/71), and we missed it. This was not a problem until v2 where source connectors started sending AlterTable requests with (some?) unmodified columns missing from the request.

This would have been a trivial change (just stop dropping columns), except duckdb does not support dropping constraints (and did not support adding constraints until recently), so the AlterTable that tries to add or remove a primary key has to be handled by recreating the table with the new structure and copying the data from the old table.

And at that point, there is a question of what order should the columns be in? I opted to add a bit of complexity to keep the original column order for existing columns, and append the new columns, preserving the order in which they got requested.