### PR TITLE
Fix gRPC & arrow builds on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,6 @@
 build
 sources
 install
-cmake-build-debug
+cmake-build-*
 gen
 protos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ include(./proto_helper.cmake)
 
 find_package(Threads REQUIRED)
 
+# Check that MD_FIVETRAN_DEPENDENCIES_DIR is set
+if(NOT DEFINED MD_FIVETRAN_DEPENDENCIES_DIR)
+  message(FATAL_ERROR "MD_FIVETRAN_DEPENDENCIES_DIR is not set. Please set it to the path where dependencies are installed and pass it in as CMake flag.")
+endif()
+
 message(WARNING "DEPENDENCIES DIR: " ${MD_FIVETRAN_DEPENDENCIES_DIR})
 
 # absl and utf8_range is required by protobuf

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ build_grpc:
 	  -DgRPC_INSTALL=ON \
 	  -DCMAKE_INSTALL_PREFIX=${MD_FIVETRAN_DEPENDENCIES_DIR}/grpc \
 	  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-	  -DCMAKE_CXX_FLAGS="-Wno-error -Wno-missing-template-arg-list-after-template-kw"
+	  -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw"
 
 	cd ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/grpc && make -j${CORES} && cmake --install .
 

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,10 @@ build_grpc:
 	  git apply ${ROOT_DIR}/dependencies-patches/abseil.patch
 
 	OPENSSL_ROOT_DIR=${MD_FIVETRAN_DEPENDENCIES_DIR}/openssl cmake -S ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/grpc -B ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/grpc \
-	  -DCMAKE_CXX_STANDARD=14 \
 	  -DgRPC_BUILD_TESTS=OFF \
 	  -DgRPC_INSTALL=ON \
+	  -DgRPC_SSL_PROVIDER=package \
+	  -DCMAKE_CXX_STANDARD=14 \
 	  -DCMAKE_INSTALL_PREFIX=${MD_FIVETRAN_DEPENDENCIES_DIR}/grpc \
 	  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	  -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw"

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,11 @@ build_connector_debug: check_dependencies get_fivetran_protos
 
 build_openssl_native:
 	mkdir -p ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}
-	mkdir -p ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}
-	cd ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR} && \
-	  wget -q -O openssl-${OPENSSL_VERSION}.tar.gz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz && \
-	  tar -xf openssl-${OPENSSL_VERSION}.tar.gz && \
-	  mv openssl-${OPENSSL_VERSION} openssl && \
-	  cd openssl && \
+	wget -q -O ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/openssl-${OPENSSL_VERSION}.tar.gz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+	tar --extract --gunzip --file ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/openssl-${OPENSSL_VERSION}.tar.gz --directory ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}
+	rm ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/openssl-${OPENSSL_VERSION}.tar.gz
+	mv ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/openssl-${OPENSSL_VERSION} ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/openssl
+	cd ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/openssl && \
 	  ./config --prefix=${MD_FIVETRAN_DEPENDENCIES_DIR}/openssl --openssldir=${MD_FIVETRAN_DEPENDENCIES_DIR}/openssl --libdir=lib no-shared zlib-dynamic no-tests && \
 	  make -j${CORES} && \
 	  make install_sw

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build_grpc:
 	  git fetch --unshallow origin && \
 	  git checkout f1f503da85d52e56aae11557b4d79a42bcaa2b86
 	# abseil is broken too (see https://github.com/abseil/abseil-cpp/issues/1241), patch until bumped to fix
-	cd ${DEPENDENCIES_SOURCE_DIR}/grpc/third_party/abseil-cpp && \
+	cd ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/grpc/third_party/abseil-cpp && \
 	  git apply ${ROOT_DIR}/dependencies-patches/abseil.patch
 
 	OPENSSL_ROOT_DIR=${MD_FIVETRAN_DEPENDENCIES_DIR}/openssl cmake -S ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/grpc -B ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/grpc \

--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,15 @@ build_grpc:
 
 build_arrow:
 	mkdir -p ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}
-	rm -rf ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/arrow
-	cd ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR} && \
-	git clone --branch apache-arrow-${ARROW_VERSION} https://github.com/apache/arrow.git && \
+	rm -rf ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/arrow ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/arrow ${MD_FIVETRAN_DEPENDENCIES_DIR}/arrow
+	git clone --branch apache-arrow-${ARROW_VERSION} --depth 1 https://github.com/apache/arrow.git ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/arrow
 	cmake -S ${MD_FIVETRAN_DEPENDENCIES_SOURCE_DIR}/arrow/cpp -B${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/arrow \
-	-DCMAKE_INSTALL_PREFIX=${MD_FIVETRAN_DEPENDENCIES_DIR}/arrow -DARROW_CSV=ON -DARROW_WITH_ZSTD=ON
-	cd ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/arrow && make -j${CORES} && cmake --install .
+	  -DARROW_BUILD_STATIC=ON -DARROW_CSV=ON -DARROW_WITH_ZSTD=ON \
+	  -DCMAKE_INSTALL_PREFIX=${MD_FIVETRAN_DEPENDENCIES_DIR}/arrow \
+	  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+	CMAKE_POLICY_VERSION_MINIMUM=3.5 cmake --build ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/arrow
+	cmake --install ${MD_FIVETRAN_DEPENDENCIES_BUILD_DIR}/arrow
 
 # versions 1.3.0 and 1.3.1 are not available; amalgamation files were built from source and checked in
 get_duckdb:

--- a/dependencies-patches/abseil.patch
+++ b/dependencies-patches/abseil.patch
@@ -1,0 +1,13 @@
+diff --git a/absl/copts/AbseilConfigureCopts.cmake b/absl/copts/AbseilConfigureCopts.cmake
+index 3f737c81..e650c9e8 100644
+--- a/absl/copts/AbseilConfigureCopts.cmake
++++ b/absl/copts/AbseilConfigureCopts.cmake
+@@ -42,7 +42,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
+     string(TOUPPER "${_arch}" _arch_uppercase)
+     string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
+     foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
+-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")
++      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch} ${_flag}")
+     endforeach()
+   endforeach()
+   # If a compiler happens to deal with an argument for a currently unused


### PR DESCRIPTION
On macOS with xcode 16, compilation of zlib and abseil will fail because of some conflicts with the standard library. This is fixed by using zlib 1.3.1 in gRPC, and patching abseil.

Furthermore, CMake 4 removed support for CMake < 3.5, and cares still lists 3.1 as minimum required version. This is fixed by adding `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` when building gRPC and arrow.

Also adds some minor improvements like using `--depth=1` for `git clone` in arrow, doing a shallow clone of gRPC submodules, using a single command per line in the Makefile which I think is more readable, and following the [arrow build guidelines](https://arrow.apache.org/docs/dev/developers/cpp/building.html#building) a bit more closely.