### PR TITLE
Print stack trace when exiting with SIGSEV or SIGABRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ generate_protos(${CMAKE_CURRENT_SOURCE_DIR}/protos/destination_sdk.proto)
 # DuckDB amalgamation
 set(DuckDB_SOURCE_DIR ./libduckdb-src)
 
+add_link_options(-rdynamic)
+add_compile_options(-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer)
 
 add_library(motherduck_destination_sources STATIC
         "src/motherduck_destination_server.cpp"
@@ -74,6 +76,7 @@ add_library(motherduck_destination_sources STATIC
         "src/fivetran_duckdb_interop.cpp"
         "src/md_logging.cpp"
         "src/extension_helper.cpp"
+        "src/stacktrace.cpp"
         ${TARGET_ROOT}/cpp/destination_sdk.pb.cc
         ${TARGET_ROOT}/cpp/destination_sdk.grpc.pb.cc
         ${TARGET_ROOT}/cpp/common.pb.cc

--- a/includes/stacktrace.hpp
+++ b/includes/stacktrace.hpp
@@ -1,0 +1,29 @@
+// Copied from DuckDB.
+// Original at https://github.com/duckdb/duckdb/blob/v1.3.2/src/include/duckdb/common/stacktrace.hpp.
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/stacktrace.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+#include <cstdint>
+
+namespace duckdb_copy {
+
+    class StackTrace {
+    public:
+        static std::string GetStacktracePointers(uint64_t max_depth = 120);
+        static std::string ResolveStacktraceSymbols(const std::string &pointers);
+
+        inline static std::string GetStackTrace(uint64_t max_depth = 120) {
+            return ResolveStacktraceSymbols(GetStacktracePointers(max_depth));
+        }
+    };
+
+} // namespace duckdb_copy

--- a/src/motherduck_destination.cpp
+++ b/src/motherduck_destination.cpp
@@ -1,5 +1,6 @@
 #include "extension_helper.hpp"
 #include "motherduck_destination_server.hpp"
+#include "stacktrace.hpp"
 #include <csignal>
 #include <execinfo.h>
 #include <grpcpp/grpcpp.h>
@@ -23,6 +24,8 @@ void RunServer(const std::string &port) {
 
 void logCrash(int sig) {
   std::cerr << "Crash signal " << sig << std::endl;
+  auto trace = duckdb_copy::StackTrace::GetStackTrace();
+  std::cerr << "Stack Trace:" << trace << std::endl;
   std::exit(sig);
 }
 

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -1,0 +1,166 @@
+// This is a slightly modified copy of src/common/stacktrace.cpp.
+// See https://github.com/duckdb/duckdb/blob/v1.3.2/src/common/stacktrace.cpp.
+
+#include "stacktrace.hpp"
+
+#if defined(__GLIBC__) || defined(__APPLE__)
+#include <execinfo.h>
+#include <cxxabi.h>
+#endif
+
+#include <string>
+#include <vector>
+#include <sstream>
+#include <memory>
+
+using namespace std;
+
+namespace duckdb_copy {
+
+namespace StringUtil {
+
+std::vector<std::string> Split(const std::string &str, char delimiter) {
+	std::stringstream ss(str);
+	std::vector<std::string> lines;
+	std::string temp;
+	while (getline(ss, temp, delimiter)) {
+		lines.push_back(temp);
+	}
+	return (lines);
+}
+
+bool CharacterIsSpace(char c) {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
+}
+
+bool CharacterIsDigit(char c) {
+	return c >= '0' && c <= '9';
+}
+
+bool CharacterIsHex(char c) {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+}
+
+#if defined(__GLIBC__) || defined(__APPLE__)
+static std::string UnmangleSymbol(std::string symbol) {
+	// find the mangled name
+	uint64_t mangle_start = symbol.size();
+	uint64_t mangle_end = 0;
+	for (uint64_t i = 0; i < symbol.size(); ++i) {
+		if (symbol[i] == '_') {
+			mangle_start = i;
+			break;
+		}
+	}
+	for (uint64_t i = mangle_start; i < symbol.size(); i++) {
+		if (StringUtil::CharacterIsSpace(symbol[i]) || symbol[i] == ')' || symbol[i] == '+') {
+			mangle_end = i;
+			break;
+		}
+	}
+	if (mangle_start >= mangle_end) {
+		return symbol;
+	}
+	std::string mangled_symbol = symbol.substr(mangle_start, mangle_end - mangle_start);
+
+	int status;
+	auto demangle_result = abi::__cxa_demangle(mangled_symbol.c_str(), nullptr, nullptr, &status);
+	if (status != 0 || !demangle_result) {
+		return symbol;
+	}
+	std::string result;
+	result += symbol.substr(0, mangle_start);
+	result += demangle_result;
+	result += symbol.substr(mangle_end);
+	free(demangle_result);
+	return result;
+}
+
+static std::string CleanupStackTrace(std::string symbol) {
+#ifdef __APPLE__
+	// structure of frame pointers is [depth] [library] [pointer] [symbol]
+	// we are only interested in [depth] and [symbol]
+
+	// find the depth
+	uint64_t start;
+	for (start = 0; start < symbol.size(); start++) {
+		if (!StringUtil::CharacterIsDigit(symbol[start])) {
+			break;
+		}
+	}
+
+	// now scan forward until we find the frame pointer
+	uint64_t frame_end = symbol.size();
+	for (uint64_t i = start; i + 1 < symbol.size(); ++i) {
+		if (symbol[i] == '0' && symbol[i + 1] == 'x') {
+			uint64_t k;
+			for (k = i + 2; k < symbol.size(); ++k) {
+				if (!StringUtil::CharacterIsHex(symbol[k])) {
+					break;
+				}
+			}
+			frame_end = k;
+			break;
+		}
+	}
+	static constexpr uint64_t STACK_TRACE_INDENTATION = 8;
+	if (frame_end == symbol.size() || start >= STACK_TRACE_INDENTATION) {
+		// frame pointer not found - just preserve the original frame
+		return symbol;
+	}
+	uint64_t space_count = STACK_TRACE_INDENTATION - start;
+	return symbol.substr(0, start) + std::string(space_count, ' ') + symbol.substr(frame_end, symbol.size() - frame_end);
+#else
+	return symbol;
+#endif
+}
+
+std::string StackTrace::GetStacktracePointers(uint64_t max_depth) {
+	std::string result;
+	auto callstack = unique_ptr<void *[]>(new void *[max_depth]);
+	int frames = backtrace(callstack.get(), static_cast<int32_t>(max_depth));
+	// skip two frames (these are always StackTrace::...)
+	for (uint64_t i = 2; i < static_cast<uint64_t>(frames); i++) {
+		if (!result.empty()) {
+			result += ";";
+		}
+		result += to_string(reinterpret_cast<uintptr_t>(callstack[i]));
+	}
+	return result;
+}
+
+template <class SRC = uint8_t>
+SRC *cast_uint64_to_pointer(uint64_t value) {
+	return reinterpret_cast<SRC *>(static_cast<uintptr_t>(value));
+}
+
+std::string StackTrace::ResolveStacktraceSymbols(const std::string &pointers) {
+	auto splits = StringUtil::Split(pointers, ';');
+	uint64_t frame_count = splits.size();
+	auto callstack = std::unique_ptr<void *[]>(new void *[frame_count]);
+	for (uint64_t i = 0; i < frame_count; i++) {
+		callstack[i] = cast_uint64_to_pointer(std::stoull(splits[i]));
+	}
+	std::string result;
+	char **strs = backtrace_symbols(callstack.get(), static_cast<int32_t>(frame_count));
+	for (uint64_t i = 0; i < frame_count; i++) {
+		result += CleanupStackTrace(UnmangleSymbol(strs[i]));
+		result += "\n";
+	}
+	free(reinterpret_cast<void *>(strs));
+	return "\n" + result;
+}
+
+#else
+std::string StackTrace::GetStacktracePointers(uint64_t max_depth) {
+	return std::string();
+}
+
+std::string StackTrace::ResolveStacktraceSymbols(const std::string &pointers) {
+	return std::string();
+}
+#endif
+
+} // namespace duckdb_copy


### PR DESCRIPTION
Includes a modified version of DuckDB's [stacktrace printing code](https://github.com/duckdb/duckdb/blob/v1.3.2/src/include/duckdb/common/stacktrace.hpp) and calls it in the `logCrash` handler.

From the [backtrace docs](https://www.man7.org/linux/man-pages/man3/backtrace.3.html):
> The symbol names may be unavailable without the use of  linker options.  For systems using the GNU linker, it is to use the -rdynamic linker option.

The `-fno-omit-frame-pointer` I added because I hope that it makes the live easier for the backtrace program, even though it should also work without. https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html

This produces stack traces with mangled names. I don't know why. But we can use any [demangler](http://demangler.com/) afterwards to get it printed nicely.