### PR TITLE
Send logging to MD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ endif()
 generate_protos(${CMAKE_CURRENT_SOURCE_DIR}/protos/common.proto)
 generate_protos(${CMAKE_CURRENT_SOURCE_DIR}/protos/destination_sdk.proto)
 
+# Motherduck logging proto
+generate_protos(${CMAKE_CURRENT_SOURCE_DIR}/protos/logging_sink.proto)
+
 # DuckDB amalgamation
 set(DuckDB_SOURCE_DIR ./libduckdb-src)
 
@@ -74,6 +77,8 @@ add_library(motherduck_destination_sources STATIC
         "src/fivetran_duckdb_interop.cpp"
         "src/md_logging.cpp"
         "src/extension_helper.cpp"
+        ${TARGET_ROOT}/cpp/logging_sink.pb.cc
+        ${TARGET_ROOT}/cpp/logging_sink.grpc.pb.cc
         ${TARGET_ROOT}/cpp/destination_sdk.pb.cc
         ${TARGET_ROOT}/cpp/destination_sdk.grpc.pb.cc
         ${TARGET_ROOT}/cpp/common.pb.cc

--- a/includes/md_logging.hpp
+++ b/includes/md_logging.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "logging_sink.grpc.pb.h"
 #include <iostream>
 #include <map>
 
@@ -17,8 +18,14 @@ public:
 
   void set_duckdb_id(const std::string &duckdb_id_);
 
+  void
+  set_remote_sink(const std::string &token_,
+                  std::shared_ptr<logging_sink::LoggingSink::Stub> &client_);
+
 private:
   std::string duckdb_id = "none";
+  std::string token;
+  std::shared_ptr<logging_sink::LoggingSink::Stub> client = nullptr;
 };
 
 std::string escape_char(const std::string &str, const char &c);

--- a/src/md_logging.cpp
+++ b/src/md_logging.cpp
@@ -13,10 +13,38 @@ std::string escape_char(const std::string &str, const char &c) {
 }
 
 void MdLog::log(const std::string &level, const std::string &message) {
-  std::cout << "{\"level\":\"" << escape_char(level, '"') << "\","
-            << "\"message\":\"" << escape_char(message, '"') << ", duckdb_id=<"
-            << duckdb_id << ">\","
-            << "\"message-origin\":\"sdk_destination\"}" << std::endl;
+  std::ostringstream json_stream;
+  json_stream << "{\"level\":\"" << escape_char(level, '"') << "\","
+              << "\"message\":\"" << escape_char(message, '"')
+              << ", duckdb_id=<" << duckdb_id << ">\","
+              << "\"message-origin\":\"sdk_destination\"}";
+  auto json_log_entry = json_stream.str();
+  // first write to stdout
+  std::cout << json_log_entry << std::endl;
+
+  // then send a single request to MotherDuck logging sink endpoint if the
+  // client is initialized
+  if (client != nullptr) {
+    auto context = std::make_shared<grpc::ClientContext>();
+    context->AddMetadata("x-md-token", token);
+    // context->AddMetadata("x-md-duckdb-version","v0.9.2");
+    // context->AddMetadata("x-md-extension-version","v1.15.22");
+
+    // just one log event, for testing
+    logging_sink::LogEventBatchRequest request;
+    logging_sink::LogEventBatchResponse response;
+    auto log_event = request.add_log_events();
+    log_event->set_json_line(json_log_entry);
+    log_event->set_level(::logging_sink::LOG_LEVEL::LL_WARN);
+    log_event->set_service("eco-fivetran-connector");
+
+		// TODO: it's fire and forget but should maybe log failure to stderr
+    const auto result =
+        client->LogEventBatch(context.get(), request, &response);
+/*    std::cout << "****** result of grpc log batch call: " << result.ok()
+              << " (error code = " << to_string(result.error_code()) + ")"
+              << " (error message = " << result.error_message() + ")";*/
+  }
 }
 
 void MdLog::info(const std::string &message) { log("INFO", message); }
@@ -27,6 +55,13 @@ void MdLog::severe(const std::string &message) { log("SEVERE", message); }
 
 void MdLog::set_duckdb_id(const std::string &duckdb_id_) {
   duckdb_id = duckdb_id_;
+}
+
+void MdLog::set_remote_sink(
+    const std::string &token_,
+    std::shared_ptr<logging_sink::LoggingSink::Stub> &client_) {
+  token = token_;
+  client = client_;
 }
 
 } // namespace mdlog


### PR DESCRIPTION
@Flogex I don't particularly want to merge this until September, but just in case a heisenbug appears where sending logs to MD would be useful for understanding what happened, this code works (`service:eco-fivetran-connector`).
It is intentionally one log at a time rather than batched, so we can get the last useful thing the code was doing before a crash.