### PR TITLE
Remove TODO section from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,3 @@ make build_connector_debug
 
 This connector uses DuckDB's amalgamation sources.
 To upgrade, change `DUCKDB_VERSION` in [Makefile](Makefile) and re-run `make get_duckdb`.
-
-## TODO
-- support GZIP compression


### PR DESCRIPTION
According to the Fivetran documentation for the Partner SDK [here](https://github.com/fivetran/fivetran_partner_sdk/blob/main/development-guide/destination-connector-development-guide.md#compression):
> Batch files are compressed using ZSTD.

There is no mention anymore of gzip. Hence, I am removing this to-do from the readme.