### PR TITLE
Disable curl progress meter when downloading protos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ get_duckdb:
 
 get_fivetran_protos:
 	mkdir -p protos
-	curl -o protos/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/destination_sdk.proto
-	curl -o protos/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/common.proto
+	curl --no-progress-meter --output protos/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/destination_sdk.proto
+	curl --no-progress-meter --output protos/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/common.proto
 
 build_dependencies: get_duckdb build_openssl_native build_grpc build_arrow build_test_dependencies
 


### PR DESCRIPTION
Disables the progress meter because it only adds noise to the output, especially in CI.