### PR TITLE
Limit "build and test" job in CI to 75 minutes

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,7 @@ jobs:
   build_and_test:
     name: Build and test the connector
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Add a timeout to fail earlier in case the job gets stuck at some point.