### PR TITLE
Set default_collation to default (empty) value on new connections

### DIFF
--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -139,6 +139,12 @@ std::unique_ptr<duckdb::Connection> DestinationSdkImpl::get_connection(
     logger->set_connection_id(client_ids_res->GetValue(1, 0).ToString());
   }
 
+  const auto set_res = con->Query("SET default_collation=''");
+  if (set_res->HasError()) {
+    throw std::runtime_error("    get_connection: Could not SET default_collation: " +
+                             set_res->GetError());
+  }
+
   logger->info("    get_connection: all done, returning connection");
   return con;
 }


### PR DESCRIPTION
To make sure the collation settings are not affected by other connections and that client and duckling use the same collation for planning and execution, sets `default_collation` to an empty string for every new connection. I am rather certain this could have also been done in `get_duckdb` once, but I'd rather pay the price for a bit more requests to get extra certainty until we understand the problem better.