### PR TITLE
Set connection time zone to UTC

### DIFF
--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -139,10 +139,20 @@ std::unique_ptr<duckdb::Connection> DestinationSdkImpl::get_connection(
     logger->set_connection_id(client_ids_res->GetValue(1, 0).ToString());
   }
 
-  const auto set_res = con->Query("SET default_collation=''");
-  if (set_res->HasError()) {
-    throw std::runtime_error("    get_connection: Could not SET default_collation: " +
-                             set_res->GetError());
+  // Set default_collation to a connection-specific default value which overwrites any global setting
+  // and ensures that client-side planning and server-side execution use the same collation.
+  const auto set_collation_res = con->Query("SET default_collation=''");
+  if (set_collation_res->HasError()) {
+    throw std::runtime_error(
+        "    get_connection: Could not SET default_collation: " +
+        set_collation_res->GetError());
+  }
+
+  // Set the time zone to UTC. This can be removed once we do not load ICU anymore.
+  const auto set_timezone_res = con->Query("SET timezone='UTC'");
+  if (set_timezone_res->HasError()) {
+    throw std::runtime_error("    get_connection: Could not SET TimeZone: " +
+                             set_timezone_res->GetError());
   }
 
   logger->info("    get_connection: all done, returning connection");

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -167,8 +167,7 @@ void MdSqlGenerator::create_schema(duckdb::Connection &con,
                                    const std::string &db_name,
                                    const std::string &schema_name) {
   std::ostringstream ddl;
-  ddl << "CREATE SCHEMA "
-      << KeywordHelper::WriteQuoted(db_name, '"') << "."
+  ddl << "CREATE SCHEMA " << KeywordHelper::WriteQuoted(db_name, '"') << "."
       << KeywordHelper::WriteQuoted(schema_name, '"');
   const std::string query = ddl.str();
 
@@ -176,8 +175,8 @@ void MdSqlGenerator::create_schema(duckdb::Connection &con,
   const auto result = con.Query(query);
   if (result->HasError()) {
     throw std::runtime_error("Could not create schema <" + schema_name +
-                             "> in database <" + db_name + ">: " +
-                             result->GetError());
+                             "> in database <" + db_name +
+                             ">: " + result->GetError());
   }
 }
 


### PR DESCRIPTION
Two tests were failing locally for me because of time zone mismatches. I think the problem is that `make_timestamp` returns a `TIMESTAMP`, but we convert Fivetran's `UTC_DATETIME` type to a `TIMESTAMP_TZ`. As a tactical fix, this sets the time zone to UTC on every connection. I have to say that it is not 100% clear to me why the tests (e.g. "WriteBatch") fail.

The problem was introduced when we started to use the pre-built libduckdb binaries because they come with the ICU extension statically linked. The problem will go away once we again build libduckdb from source (without ICU).

Also in this PR:
- Add comment describing why we need to run `SET default_collation`
- Formatting