### PR TITLE
In test_config_tester.cpp, use `ATTACH OR REPLACE` to attach share

### DIFF
--- a/test/integration/common.hpp
+++ b/test/integration/common.hpp
@@ -47,6 +47,7 @@ inline bool REQUIRE_FAIL(const grpc::Status& status, const Catch::Matchers::Stri
 }
 
 #define REQUIRE_NO_FAIL(result) REQUIRE(NO_FAIL((result)))
+#define CHECK_NO_FAIL(result) CHECK(NO_FAIL((result)))
 
 class testRunListener : public Catch::EventListenerBase {
 public:

--- a/test/integration/test_config_tester.cpp
+++ b/test/integration/test_config_tester.cpp
@@ -93,7 +93,8 @@ TEST_CASE("Test fails when motherduck_database is a share", "[integration][confi
 	::fivetran_sdk::v2::TestResponse response;
 	const auto status = service.Test(nullptr, &request, &response);
 
-	con->Query("DETACH IF EXISTS " + share_name);
+	CHECK_NO_FAIL(con->Query("DETACH DATABASE IF EXISTS " + share_name));
+	CHECK_NO_FAIL(con->Query("DROP SHARE " + share_name));
 
 	REQUIRE_NO_FAIL(status);
 	CAPTURE(response.failure());

--- a/test/integration/test_config_tester.cpp
+++ b/test/integration/test_config_tester.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Test fails when motherduck_database is a share", "[integration][confi
 	REQUIRE(create_res->ColumnCount() == 1);
 	const auto share_url = create_res->GetValue(0, 0).ToString();
 
-	const auto attach_res = con->Query("ATTACH IF NOT EXISTS '" + share_url + "'");
+	const auto attach_res = con->Query("ATTACH OR REPLACE '" + share_url + "'");
 	REQUIRE_NO_FAIL(attach_res);
 
 	::fivetran_sdk::v2::TestRequest request;


### PR DESCRIPTION
The test "Test fails when motherduck_database is a share" sporadically fails.
@elefeint Tagging you because you might be interested in the analysis.

## Error in Failing Test

The test fails with the following error:

```
-------------------------------------------------------------------------------
Test fails when motherduck_database is a share
-------------------------------------------------------------------------------
/home/runner/work/motherduck-fivetran-connector/motherduck-fivetran-connector/test/integration/test_config_tester.cpp:66
...............................................................................

/home/runner/work/motherduck-fivetran-connector/motherduck-fivetran-connector/test/integration/test_config_tester.cpp:100: FAILED:
  REQUIRE_THAT( response.failure(), Catch::Matchers::ContainsSubstring("is a read-only MotherDuck share") )
with expansion:
  "Test <test_database_type> failed: Connection to MotherDuck failed: "Failed
  to attach '_share/fivetran_test_share/efe5951c-912b-4f79-94a6-a8c166c09171':
  no database/share named '_share/fivetran_test_share/efe5951c-912b-4f79-94a6-
  a8c166c09171' found. Create it first in your MotherDuck account."" contains:
  "is a read-only MotherDuck share"
```

Example of failing run: https://github.com/motherduckdb/motherduck-fivetran-connector/actions/runs/22701571469/job/65819559010

The test first runs:
```cpp
CREATE OR REPLACE SHARE fivetran_test_share FROM fivetran_test_db1234; # Returns share URL
ATTACH IF NOT EXISTS '<share_url>';
```

The `ATTACH` query is run on the test connection which connects in workspace mode.

Then it sends a `TestRequest` to the Fivetran connector with `motherduck_database` set to "fivetran_test_share". This implies that the connector creates a new DuckDB instance with connection string `md:fivetran_test_share`. However, this fails with the error: "no database/share named '_share/fivetran_test_share/efe5…' found."

What is interesting is that the error message is not "no database/share named 'fivetran_test_share' found." Instead, it seems like the share URL is used for some reason for the attachment.
But the error is happening in _test_config_tester.cpp:100_, so this is definitely happening during the `TestRequest`.

## Hypothesis

- From a previous run, `fivetran_test_share` is still attached in the workspace, pointing to an old share URL.
- The test runs `CREATE OR REPLACE SHARE fivetran_test_share`. The old share is dropped and detached from the workspace. However, the client still has the share attached because the background catalog sync did not happen yet.
- The test runs `ATTACH IF NOT EXISTS`. Because on the client, a share with the same name already exists, the query is a no-op.

This could also explain why the error message shows the share URL, not the share name: Because the server (or does this happen on the client?) translates the share name to the URL and tries to attach it.

One could build a reproducer for this; I didn't do this and am instead just going to see if this PR fixes the situation or if the test will still be flaky.

## The Fix

We use `ATTACH IF NOT EXISTS` to ignore any errors if there happens to be a share with the same name already. 
Now we use `ATTACH OR REPLACE` (which is relatively new in DuckDB) to overwrite an existing attachment.