### PR TITLE
Do not base64 decode unmodified strings in blob columns

### DIFF
--- a/src/csv_processor.cpp
+++ b/src/csv_processor.cpp
@@ -118,16 +118,18 @@ CompressionType determine_compression_type(const std::string& file_path) {
 }
 
 /// Adds a SELECT clause with the specified columns to the query
-void add_projections(std::ostringstream& query, const std::vector<column_def>& columns) {
+void add_projections(std::ostringstream& query, const std::vector<column_def>& columns,
+                     const bool allow_unmodified_string) {
 	query << " SELECT";
 
 	if (columns.empty()) {
 		query << " *";
 	} else {
 		for (const auto& column : columns) {
-			if (column.type == duckdb::LogicalTypeId::BLOB) {
-				// The CSV reader reads BLOBs as VARCHARs. We have to convert them with
-				// from_base64.
+			if (!allow_unmodified_string && column.type == duckdb::LogicalTypeId::BLOB) {
+				// The CSV reader reads BLOBs as VARCHARs. We have to convert them with from_base64.
+				// However, when there could be unmodified_strings, we should not convert the strings back to their
+				// original types yet.
 				query << " from_base64(" << duckdb::KeywordHelper::WriteQuoted(column.name, '"') << ") AS "
 				      << duckdb::KeywordHelper::WriteQuoted(column.name, '"');
 			} else {
@@ -249,7 +251,7 @@ std::string generate_read_csv_query(const std::string& filepath, const IngestPro
 	query << ")";
 
 	// Select columns explicitly to enforce order
-	add_projections(query, props.columns);
+	add_projections(query, props.columns, props.allow_unmodified_string);
 
 	return query.str();
 }

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -673,6 +673,8 @@ void MdSqlGenerator::add_partial_historical_values(duckdb::Connection& con, cons
 		out << staging_table_name << "." << column->quoted();
 	});
 
+	sql << ",  ";
+
 	join(sql, columns_regular, [&](std::ostream& out, const column_def* column) {
 		auto quoted_col = KeywordHelper::WriteQuoted(column->name, '"');
 		std::ostringstream staging_col_expr;

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -618,13 +618,28 @@ void MdSqlGenerator::update_values(duckdb::Connection& con, const table_def& tab
 
 	sql << "UPDATE " << absolute_table_name << " SET ";
 
-	write_joined(sql, columns_regular,
-	             [staging_table_name, absolute_table_name, unmodified_string](const std::string quoted_col,
-	                                                                          std::ostringstream& out) {
-		             out << quoted_col << " = CASE WHEN " << staging_table_name << "." << quoted_col << " = "
-		                 << KeywordHelper::WriteQuoted(unmodified_string, '\'') << " THEN " << absolute_table_name
-		                 << "." << quoted_col << " ELSE " << staging_table_name << "." << quoted_col << " END";
-	             });
+	bool first = true;
+
+	for (const auto& col : columns_regular) {
+		if (!first) {
+			sql << ", ";
+		}
+		first = false;
+
+		auto quoted_col = KeywordHelper::WriteQuoted(col->name, '"');
+		std::ostringstream staging_col_expr;
+
+		// blobs have to be converted late for update files because unmodified_string could be used.
+		if (col->type == duckdb::LogicalTypeId::BLOB) {
+			staging_col_expr << "from_base64(" << staging_table_name << "." << quoted_col << ")";
+		} else {
+			staging_col_expr << staging_table_name << "." << quoted_col;
+		}
+
+		sql << quoted_col << " = CASE WHEN " << staging_table_name << "." << quoted_col << " = "
+		    << KeywordHelper::WriteQuoted(unmodified_string, '\'') << " THEN " << absolute_table_name << "."
+		    << quoted_col << " ELSE " << staging_col_expr.str() << " END";
+	}
 
 	sql << " FROM " << staging_table_name << " WHERE ";
 	write_joined(

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -604,28 +604,20 @@ void MdSqlGenerator::update_values(duckdb::Connection& con, const table_def& tab
 
 	sql << "UPDATE " << absolute_table_name << " SET ";
 
-	bool first = true;
-
-	for (const auto& col : columns_regular) {
-		if (!first) {
-			sql << ", ";
-		}
-		first = false;
-
-		auto quoted_col = KeywordHelper::WriteQuoted(col->name, '"');
+	join(sql, columns_regular, [&](std::ostream& out, const column_def* column) {
+		auto quoted_col = KeywordHelper::WriteQuoted(column->name, '"');
 		std::ostringstream staging_col_expr;
 
-		// blobs have to be converted late for update files because unmodified_string could be used.
-		if (col->type == duckdb::LogicalTypeId::BLOB) {
+		if (column->type == duckdb::LogicalTypeId::BLOB) {
 			staging_col_expr << "from_base64(" << staging_table_name << "." << quoted_col << ")";
 		} else {
 			staging_col_expr << staging_table_name << "." << quoted_col;
 		}
 
-		sql << quoted_col << " = CASE WHEN " << staging_table_name << "." << quoted_col << " = "
+		out << quoted_col << " = CASE WHEN " << staging_table_name << "." << quoted_col << " = "
 		    << KeywordHelper::WriteQuoted(unmodified_string, '\'') << " THEN " << absolute_table_name << "."
 		    << quoted_col << " ELSE " << staging_col_expr.str() << " END";
-	}
+	});
 
 	sql << " FROM " << staging_table_name << " WHERE ";
 	join(sql, columns_pk, " AND ", [&](std::ostream& out, const column_def* column) {
@@ -681,30 +673,20 @@ void MdSqlGenerator::add_partial_historical_values(duckdb::Connection& con, cons
 		out << staging_table_name << "." << column->quoted();
 	});
 
-	sql << ",  ";
-
-	bool first = true;
-
-	for (const auto& col : columns_regular) {
-		if (!first) {
-			sql << ", ";
-		}
-		first = false;
-
-		auto quoted_col = KeywordHelper::WriteQuoted(col->name, '"');
+	join(sql, columns_regular, [&](std::ostream& out, const column_def* column) {
+		auto quoted_col = KeywordHelper::WriteQuoted(column->name, '"');
 		std::ostringstream staging_col_expr;
 
-		// blobs have to be converted late for update files because unmodified_string could be used.
-		if (col->type == duckdb::LogicalTypeId::BLOB) {
+		if (column->type == duckdb::LogicalTypeId::BLOB) {
 			staging_col_expr << "from_base64(" << staging_table_name << "." << quoted_col << ")";
 		} else {
 			staging_col_expr << staging_table_name << "." << quoted_col;
 		}
 
-		sql << "CASE WHEN " << staging_table_name << "." << quoted_col << " = "
+		out << "CASE WHEN " << staging_table_name << "." << quoted_col << " = "
 		    << KeywordHelper::WriteQuoted(unmodified_string, '\'') << " THEN lar." << quoted_col << " ELSE "
 		    << staging_col_expr.str() << " END as " << quoted_col;
-	}
+	});
 
 	sql << " FROM " << staging_table_name << " LEFT JOIN " << lar_table_name << " AS lar ON "
 	    << primary_key_join(columns_pk, "lar", staging_table_name) << ")";

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -699,12 +699,28 @@ void MdSqlGenerator::add_partial_historical_values(duckdb::Connection& con, cons
 	    ", ");
 	sql << ",  ";
 
-	write_joined(sql, columns_regular,
-	             [staging_table_name, unmodified_string](const std::string quoted_col, std::ostringstream& out) {
-		             out << "CASE WHEN " << staging_table_name << "." << quoted_col << " = "
-		                 << KeywordHelper::WriteQuoted(unmodified_string, '\'') << " THEN lar." << quoted_col
-		                 << " ELSE " << staging_table_name << "." << quoted_col << " END as " << quoted_col;
-	             });
+	bool first = true;
+
+	for (const auto& col : columns_regular) {
+		if (!first) {
+			sql << ", ";
+		}
+		first = false;
+
+		auto quoted_col = KeywordHelper::WriteQuoted(col->name, '"');
+		std::ostringstream staging_col_expr;
+
+		// blobs have to be converted late for update files because unmodified_string could be used.
+		if (col->type == duckdb::LogicalTypeId::BLOB) {
+			staging_col_expr << "from_base64(" << staging_table_name << "." << quoted_col << ")";
+		} else {
+			staging_col_expr << staging_table_name << "." << quoted_col;
+		}
+
+		sql << "CASE WHEN " << staging_table_name << "." << quoted_col << " = "
+		    << KeywordHelper::WriteQuoted(unmodified_string, '\'') << " THEN lar." << quoted_col << " ELSE "
+		    << staging_col_expr.str() << " END as " << quoted_col;
+	}
 
 	sql << " FROM " << staging_table_name << " LEFT JOIN " << lar_table_name << " AS lar ON "
 	    << primary_key_join(columns_pk, "lar", staging_table_name) << ")";

--- a/test/files/blob_update.csv
+++ b/test/files/blob_update.csv
@@ -1,0 +1,2 @@
+id,title,blob,_fivetran_deleted,_fivetran_synced
+1,"unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",dGVzdCBiaW5hcnk=,false,"2024-02-08T23:59:59.999999999Z"

--- a/test/files/csv/unmodified_string.csv
+++ b/test/files/csv/unmodified_string.csv
@@ -1,3 +1,3 @@
-id,name,age
-1,unmodified_string,30
-2,Bob,"unmodified_string"
+id,name,age,blob
+1,unmodified_string,30,dGVzdAo=
+2,Bob,"unmodified_string",unmodified_string

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -310,6 +310,52 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 	}
 }
 
+TEST_CASE("WriteBatch with blob and unmodified string", "[integration][write-batch]") {
+	DestinationSdkImpl service;
+
+	const std::string table_name = "blob" + std::to_string(randint());
+
+	const std::array columns {
+	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
+	    column_def {.name = "title", .type = duckdb::LogicalTypeId::VARCHAR},
+	    column_def {.name = "blob", .type = duckdb::LogicalTypeId::BLOB},
+	    column_def {.name = "_fivetran_deleted", .type = duckdb::LogicalTypeId::BOOLEAN},
+	    column_def {.name = "_fivetran_synced", .type = duckdb::LogicalTypeId::TIMESTAMP_TZ},
+	};
+	create_table(service, table_name, columns);
+
+	auto con = get_test_connection(MD_TOKEN);
+	{
+		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'Test title', null, false, NOW())");
+		REQUIRE_NO_FAIL(res);
+	}
+
+	{
+		// update
+		::fivetran_sdk::v2::WriteBatchRequest request;
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME);
+		request.mutable_file_params()->set_unmodified_string("unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3");
+		request.mutable_file_params()->set_null_string("magic-nullvalue");
+		define_table(request, table_name, columns);
+		const std::string filename = "blob_update.csv";
+		const std::string filepath = TEST_RESOURCES_DIR + filename;
+
+		request.add_update_files(filepath);
+
+		::fivetran_sdk::v2::WriteBatchResponse response;
+		auto status = service.WriteBatch(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+	}
+
+	{
+		// check inserted rows
+		auto res = con->Query("SELECT id, title, blob FROM " + table_name + " ORDER BY id");
+		REQUIRE_NO_FAIL(res);
+		REQUIRE(res->RowCount() == 1);
+		check_row(res, 0, {1, "Test title", "test binary"});
+	}
+}
+
 TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 	DestinationSdkImpl service;
 

--- a/test/test_process_file.cpp
+++ b/test/test_process_file.cpp
@@ -2,6 +2,7 @@
 #include "constants.hpp"
 #include "csv_processor.hpp"
 #include "duckdb.hpp"
+#include "integration/common.hpp"
 #include "md_error.hpp"
 #include "schema_types.hpp"
 
@@ -358,32 +359,27 @@ TEST_CASE("Test reading CSV file with unmodified string setting", "[csv_processo
 	duckdb::DuckDB db(nullptr);
 	duckdb::Connection con(db);
 
-	const std::vector<column_def> columns {column_def {.name = "id", .type = duckdb::LogicalType::INTEGER},
-	                                       column_def {.name = "name", .type = duckdb::LogicalType::VARCHAR},
-	                                       column_def {.name = "age", .type = duckdb::LogicalType::SMALLINT}};
+	const std::vector<column_def> columns {
+	    column_def {.name = "id", .type = duckdb::LogicalType::INTEGER},
+	    column_def {.name = "name", .type = duckdb::LogicalType::VARCHAR},
+	    column_def {.name = "age", .type = duckdb::LogicalType::SMALLINT},
+	    column_def {.name = "blob", .type = duckdb::LogicalType::BLOB},
+	};
 	IngestProperties props {.filename = test_file.string(), .columns = columns, .allow_unmodified_string = true};
 	auto logger = mdlog::Logger::CreateNopLogger();
 	csv_processor::ProcessFile(con, props, logger, [&con](const std::string& staging_table_name) {
-		const auto res = con.Query("FROM " + staging_table_name);
+		auto res = con.Query("FROM " + staging_table_name);
 		REQUIRE_FALSE(res->HasError());
-		REQUIRE(res->ColumnCount() == 3);
+		REQUIRE(res->ColumnCount() == 4);
 		REQUIRE(res->RowCount() == 2);
 
 		CHECK(res->types[0] == duckdb::LogicalTypeId::VARCHAR);
 		CHECK(res->types[1] == duckdb::LogicalTypeId::VARCHAR);
 		CHECK(res->types[2] == duckdb::LogicalTypeId::VARCHAR);
+		CHECK(res->types[3] == duckdb::LogicalTypeId::VARCHAR);
 
-		for (idx_t row = 0; row < res->RowCount(); row++) {
-			if (row == 0) {
-				REQUIRE("1" == res->GetValue(0, row).ToString());
-				REQUIRE("unmodified_string" == res->GetValue(1, row).ToString());
-				REQUIRE("30" == res->GetValue(2, row).ToString());
-			} else if (row == 1) {
-				REQUIRE("2" == res->GetValue(0, row).ToString());
-				REQUIRE("Bob" == res->GetValue(1, row).ToString());
-				REQUIRE("unmodified_string" == res->GetValue(2, row).ToString());
-			}
-		}
+		check_row(res, 0, {"1", "unmodified_string", "30", "dGVzdAo="});
+		check_row(res, 1, {"2", "Bob", "unmodified_string", "unmodified_string"});
 	});
 }
 


### PR DESCRIPTION
Do not base64 decode during CSV reading if we allow unmodified strings, instead always base64 decode blob columns for update files while distinguishing between unmodified strings.