### PR TITLE
Add test for history mode base64 decoding of update files

### DIFF
--- a/test/files/books_history_earlier_upsert_1.csv
+++ b/test/files/books_history_earlier_upsert_1.csv
@@ -1,4 +1,4 @@
-id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active
-1,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
-2,"The Two Towers",14,false,"2024-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
-3,"The Hobbit 2",14,false,"2024-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
+id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active,blob
+1,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=
+2,"The Two Towers",14,false,"2024-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=
+3,"The Hobbit 2",14,false,"2024-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=

--- a/test/files/books_history_earlier_upsert_2.csv
+++ b/test/files/books_history_earlier_upsert_2.csv
@@ -1,2 +1,2 @@
-id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active
-2,"The Two Towers Updated Title",14,false,"2024-01-09T04:10:19.156057706Z","2024-01-01T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
+id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active,blob
+2,"The Two Towers Updated Title",14,false,"2024-01-09T04:10:19.156057706Z","2024-01-01T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=

--- a/test/files/books_history_update.csv
+++ b/test/files/books_history_update.csv
@@ -1,3 +1,3 @@
-id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active
-3,"unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",123,false,"2025-02-08T12:00:00.000Z","2025-02-08T12:00:00.000Z","9999-02-08T12:00:00.000Z",true
-2,"The empire strikes back","unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",false,"2025-02-08T12:00:00.000Z","2025-02-08T12:00:00.000Z","9999-02-08T12:00:00.000Z",true
+id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active,blob
+3,"unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",123,false,"2025-02-08T12:00:00.000Z","2025-02-08T12:00:00.000Z","9999-02-08T12:00:00.000Z",true,dGVzdAo=
+2,"The empire strikes back","unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",false,"2025-02-08T12:00:00.000Z","2025-02-08T12:00:00.000Z","9999-02-08T12:00:00.000Z",true,dGVzdAo=

--- a/test/files/books_history_upsert.csv
+++ b/test/files/books_history_upsert.csv
@@ -1,2 +1,2 @@
-id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active
-3,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
+id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active,blob
+3,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=

--- a/test/files/books_history_upsert_regular_write.csv
+++ b/test/files/books_history_upsert_regular_write.csv
@@ -1,5 +1,5 @@
-id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active
-3,"The old Hobbit",100,false,"2023-01-09T04:10:19.156057706Z","2023-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.155957706Z",false
-3,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
-2,"The Two Towers",1,false,"2025-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
-99,"null","magic-nullvalue",false,"2025-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true
+id,title,magic_number,_fivetran_deleted,_fivetran_synced,_fivetran_start,_fivetran_end,_fivetran_active,blob
+3,"The old Hobbit",100,false,"2023-01-09T04:10:19.156057706Z","2023-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.155957706Z",false,dGVzdAo=
+3,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=
+2,"The Two Towers",1,false,"2025-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=
+99,"null","magic-nullvalue",false,"2025-01-09T04:10:19.156057706Z","2025-01-09T04:10:19.156057706Z","9999-01-09T04:10:19.156057706Z",true,dGVzdAo=

--- a/test/files/history_reordered_initial.csv
+++ b/test/files/history_reordered_initial.csv
@@ -1,3 +1,3 @@
-_fivetran_end,magic_number,_fivetran_active,title,_fivetran_synced,_fivetran_start,_fivetran_deleted,id
-"9999-01-09T04:10:19.156057706Z",100,true,"Initial Book","2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z",false,1
-"9999-01-09T04:10:19.156057706Z",200,true,"Second Book","2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z",false,2
+_fivetran_end,magic_number,_fivetran_active,title,_fivetran_synced,_fivetran_start,_fivetran_deleted,id,blob
+"9999-01-09T04:10:19.156057706Z",100,true,"Initial Book","2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z",false,1,dGVzdA==
+"9999-01-09T04:10:19.156057706Z",200,true,"Second Book","2024-01-09T04:10:19.156057706Z","2024-01-09T04:10:19.156057706Z",false,2,dGVzdA==

--- a/test/files/history_reordered_update.csv
+++ b/test/files/history_reordered_update.csv
@@ -1,3 +1,3 @@
-_fivetran_active,magic_number,title,_fivetran_synced,_fivetran_start,_fivetran_deleted,id,_fivetran_end
-true,999,"Updated Book","2025-03-01T10:00:00.000Z","2025-03-01T10:00:00.000Z",false,1,"9999-03-01T10:00:00.000Z"
-true,"unmod-testmarker","unmod-testmarker","2025-03-01T10:00:00.000Z","2025-03-01T10:00:00.000Z",false,2,"9999-03-01T10:00:00.000Z"
+_fivetran_active,magic_number,title,_fivetran_synced,_fivetran_start,_fivetran_deleted,id,_fivetran_end,blob
+true,999,"Updated Book","2025-03-01T10:00:00.000Z","2025-03-01T10:00:00.000Z",false,1,"9999-03-01T10:00:00.000Z","unmod-testmarker"
+true,"unmod-testmarker","unmod-testmarker","2025-03-01T10:00:00.000Z","2025-03-01T10:00:00.000Z",false,2,"9999-03-01T10:00:00.000Z",dGVzdCBuZXc=

--- a/test/integration/common.hpp
+++ b/test/integration/common.hpp
@@ -110,6 +110,7 @@ const std::array HISTORY_TEST_COLUMNS = {
     column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
     column_def {.name = "title", .type = duckdb::LogicalTypeId::VARCHAR},
     column_def {.name = "magic_number", .type = duckdb::LogicalTypeId::INTEGER},
+    column_def {.name = "blob", .type = duckdb::LogicalTypeId::BLOB},
     column_def {.name = "_fivetran_synced", .type = duckdb::LogicalTypeId::TIMESTAMP_TZ},
     column_def {.name = "_fivetran_active", .type = duckdb::LogicalTypeId::BOOLEAN},
     column_def {.name = "_fivetran_start", .type = duckdb::LogicalTypeId::TIMESTAMP_TZ, .primary_key = true},
@@ -195,6 +196,7 @@ void define_history_test_table_reordered(T& request, const std::string& table_na
 	add_col(request, "_fivetran_synced", ::fivetran_sdk::v2::DataType::UTC_DATETIME, false);
 	add_col(request, "_fivetran_start", ::fivetran_sdk::v2::DataType::UTC_DATETIME, true);
 	add_col(request, "id", ::fivetran_sdk::v2::DataType::INT, true);
+	add_col(request, "blob", ::fivetran_sdk::v2::DataType::BINARY, false);
 }
 
 template <std::size_t N>

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -1256,14 +1256,14 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with reordered CSV columns", "[integ
 	auto con = get_test_connection(MD_TOKEN);
 	{
 		// Verify initial data was inserted correctly despite column order mismatch
-		auto res = con->Query("SELECT id, title, magic_number, _fivetran_active"
+		auto res = con->Query("SELECT id, title, magic_number, blob, _fivetran_active"
 		                      " FROM " +
 		                      table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 
-		check_row(res, 0, {1, "Initial Book", 100, true});
-		check_row(res, 1, {2, "Second Book", 200, true});
+		check_row(res, 0, {1, "Initial Book", 100, "test", true});
+		check_row(res, 1, {2, "Second Book", 200, "test", true});
 	}
 
 	{
@@ -1289,13 +1289,13 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with reordered CSV columns", "[integ
 	{
 		// Verify the update was applied correctly - id=1 should have new values,
 		// id=2 should have preserved values from the unmodified marker
-		auto res = con->Query("SELECT id, title, magic_number FROM " + table_name +
+		auto res = con->Query("SELECT id, title, magic_number, blob FROM " + table_name +
 		                      " WHERE _fivetran_start >= '2025-03-01' ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 
-		check_row(res, 0, {1, "Updated Book", 999}); // updated
-		check_row(res, 1, {2, "Second Book", 200});  // preserved via unmodified marker
+		check_row(res, 0, {1, "Updated Book", 999, "test"});    // updated title
+		check_row(res, 1, {2, "Second Book", 200, "test new"}); // updated blob
 	}
 }
 


### PR DESCRIPTION
As a follow up on https://github.com/motherduckdb/motherduck-fivetran-connector/pull/163, I figured this should also be covered for history mode in the tests.