### PR TITLE
Allow existing columns for AddColumnWithDefaultValue

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -211,7 +211,7 @@ public:
 	void migrate_soft_delete_to_history(duckdb::Connection& con, const table_def& original_table,
 	                                    const std::string& soft_deleted_column);
 	void add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns, const std::string& table_name,
-	                  const std::string& log_prefix);
+	                  const std::string& log_prefix, const bool with_cast = false);
 	void add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk,
 	             const std::string& table_name, const std::string& log_prefix) const;
 

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -211,7 +211,7 @@ public:
 	void migrate_soft_delete_to_history(duckdb::Connection& con, const table_def& original_table,
 	                                    const std::string& soft_deleted_column);
 	void add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns, const std::string& table_name,
-	                  const std::string& log_prefix, const bool with_cast = false);
+	                  const std::string& log_prefix);
 	void add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk,
 	             const std::string& table_name, const std::string& log_prefix) const;
 

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -812,20 +812,18 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 					                            ">. Please contact Fivetran support.");
 				}
 
+				// After seeing errors, Fivetran told us they invoke AddColumnWithDefaultValue even when the column
+				// exists. They expect only the default value to change in that case.
+
 				const auto columns = sql_generator->describe_table(con, table);
-				bool existing = false;
+				const bool column_exists = std::any_of(columns.begin(), columns.end(), [new_column](const auto& col) {
+					return col.name == new_column.name;
+				});
 
-				for (auto& col : columns) {
-					if (col.name == new_column.name) {
-						sql_generator->add_defaults(con, {new_column}, table_name, "add_column", true);
-						existing = true;
-						break;
-					}
-				}
-
-				if (!existing) {
-					// After seeing errors, Fivetran told us they invoke AddColumnWithDefaultValue even when the column
-					// exists, but expect the default value to change in that case.
+				if (column_exists) {
+					// If the column already exists, only the default value should be changed.
+					sql_generator->add_defaults(con, {new_column}, table_name, "add_column", true);
+				} else {
 					sql_generator->add_column(con, table, new_column, "add_column", true);
 				}
 				break;

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -817,7 +817,7 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 
 				for (auto& col : columns) {
 					if (col.name == new_column.name) {
-						sql_generator->add_defaults(con, {new_column}, table_name, "add_column");
+						sql_generator->add_defaults(con, {new_column}, table_name, "add_column", true);
 						existing = true;
 						break;
 					}

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -800,19 +800,34 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 				logger.info("Endpoint <Migrate>: ADD_COLUMN_WITH_DEFAULT_VALUE");
 				const auto& add_col = add.add_column_with_default_value();
 
-				column_def column {
+				column_def new_column {
 				    .name = add_col.column(),
 				    .type = get_duckdb_type(add_col.column_type()),
 				    .column_default = add_col.default_value(),
 				    .primary_key = false,
 				};
 
-				if (is_fivetran_system_column(column.name)) {
-					throw std::invalid_argument("Cannot add column with reserved name <" + column.name +
+				if (is_fivetran_system_column(new_column.name)) {
+					throw std::invalid_argument("Cannot add column with reserved name <" + new_column.name +
 					                            ">. Please contact Fivetran support.");
 				}
 
-				sql_generator->add_column(con, table, column, "add_column");
+				const auto columns = sql_generator->describe_table(con, table);
+				bool existing = false;
+
+				for (auto& col : columns) {
+					if (col.name == new_column.name) {
+						sql_generator->add_defaults(con, {new_column}, table_name, "add_column");
+						existing = true;
+						break;
+					}
+				}
+
+				if (!existing) {
+					// After seeing errors, Fivetran told us they invoke AddColumnWithDefaultValue even when the column
+					// exists, but expect the default value to change in that case.
+					sql_generator->add_column(con, table, new_column, "add_column", true);
+				}
 				break;
 			}
 			case fivetran_sdk::v2::AddOperation::EntityCase::kAddColumnInHistoryMode: {

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -822,9 +822,9 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 
 				if (column_exists) {
 					// If the column already exists, only the default value should be changed.
-					sql_generator->add_defaults(con, {new_column}, table_name, "add_column", true);
+					sql_generator->add_defaults(con, {new_column}, table_name, "add_column");
 				} else {
-					sql_generator->add_column(con, table, new_column, "add_column", true);
+					sql_generator->add_column(con, table, new_column, "add_column");
 				}
 				break;
 			}

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -982,7 +982,9 @@ void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<col
 			    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
 			    << format_type(col) << ");";
 		} else {
-			// If the defaults come from describe_table, the default values will already contain a CAST statement.
+			// The default in col.column_default can already contain a CAST-statement, because the columns passed to
+			// this method were generate with describe_table(). This resulted in e.g. "CAST(CAST(\'42\' as int))" being
+			// generated. To prevent this, the caller can specify if it needs an extra CAST around the default values.
 			sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
 			    << " SET DEFAULT " << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << ";";
 		}

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -970,15 +970,15 @@ void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<col
 	// Copies the default of every column that has a default defined to the destination table_name. This assumes all
 	// columns are present in the destination table.
 	for (const auto& col : columns) {
-		// This also sets the default value of the soft_deleted_column if it was not
-		// equal to _fivetran_deleted
+		// This also sets the default value of the soft_deleted_column if it was not equal to _fivetran_deleted
 		if (!col.column_default.has_value() || col.column_default.value() == "NULL") {
 			continue;
 		}
 
 		std::ostringstream sql;
 		sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
-		    << " SET DEFAULT " << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << ";";
+		    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
+		    << format_type(col) << ");";
 		run_query(con, log_prefix, sql.str(), "Could not add default to column " + col.name);
 	}
 }

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -966,7 +966,7 @@ void MdSqlGenerator::copy_table(duckdb::Connection& con, const table_def& from_t
 }
 
 void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns,
-                                  const std::string& table_name, const std::string& log_prefix) {
+                                  const std::string& table_name, const std::string& log_prefix, const bool with_cast) {
 	// Copies the default of every column that has a default defined to the destination table_name. This assumes all
 	// columns are present in the destination table.
 	for (const auto& col : columns) {
@@ -976,9 +976,17 @@ void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<col
 		}
 
 		std::ostringstream sql;
-		sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
-		    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
-		    << format_type(col) << ");";
+
+		if (with_cast) {
+			sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
+			    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
+			    << format_type(col) << ");";
+		} else {
+			// If the defaults come from describe_table, the default values will already contain a CAST statement.
+			sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
+			    << " SET DEFAULT " << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << ";";
+		}
+
 		run_query(con, log_prefix, sql.str(), "Could not add default to column " + col.name);
 	}
 }
@@ -1358,7 +1366,7 @@ void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, con
 	                 .type = duckdb::LogicalTypeId::BOOLEAN,
 	                 .column_default = "false",
 	             }},
-	             temp_table_name, "migrate_history_to_soft_delete set_deleted_default");
+	             temp_table_name, "migrate_history_to_soft_delete set_deleted_default", true);
 
 	// _fivetran_start, _fivetran_end and _fivetran_active are not present in temp_table.
 	std::vector<column_def> new_columns;

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -966,7 +966,7 @@ void MdSqlGenerator::copy_table(duckdb::Connection& con, const table_def& from_t
 }
 
 void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns,
-                                  const std::string& table_name, const std::string& log_prefix, const bool with_cast) {
+                                  const std::string& table_name, const std::string& log_prefix) {
 	// Copies the default of every column that has a default defined to the destination table_name. This assumes all
 	// columns are present in the destination table.
 	for (const auto& col : columns) {
@@ -977,17 +977,13 @@ void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<col
 
 		std::ostringstream sql;
 
-		if (with_cast) {
-			sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
-			    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
-			    << format_type(col) << ");";
-		} else {
-			// The default in col.column_default can already contain a CAST-statement, because the columns passed to
-			// this method were generate with describe_table(). This resulted in e.g. "CAST(CAST(\'42\' as int))" being
-			// generated. To prevent this, the caller can specify if it needs an extra CAST around the default values.
-			sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
-			    << " SET DEFAULT " << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << ";";
-		}
+		// The default in col.column_default can already contain a CAST-statement, because the columns passed to
+		// this method were generated with describe_table(). This results in e.g. "CAST(CAST(\'42\' as int) as int)"
+		// being generated. We decided that we are find with this edge-case for now since this is still a valid default
+		// and makes this method more usable.
+		sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
+		    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
+		    << format_type(col) << ");";
 
 		run_query(con, log_prefix, sql.str(), "Could not add default to column " + col.name);
 	}
@@ -1368,7 +1364,7 @@ void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, con
 	                 .type = duckdb::LogicalTypeId::BOOLEAN,
 	                 .column_default = "false",
 	             }},
-	             temp_table_name, "migrate_history_to_soft_delete set_deleted_default", true);
+	             temp_table_name, "migrate_history_to_soft_delete set_deleted_default");
 
 	// _fivetran_start, _fivetran_end and _fivetran_active are not present in temp_table.
 	std::vector<column_def> new_columns;

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -294,10 +294,10 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		REQUIRE(res->RowCount() == 4); // The order is: id, data, value, amount
 
 		// duckdb::Value() creates a NULL value
-		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                 // id
-		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});       // data
-		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17,4))", duckdb::Value(), "DECIMAL(17,4)"});        // value
-		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"}); // amount
+		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                                 // id
+		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});                       // data
+		check_row(res, 2, {"\'42\'", duckdb::Value(), "DECIMAL(17,4)"}); // value
+		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"});                 // amount
 	}
 
 	// Clean up

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -294,10 +294,10 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		REQUIRE(res->RowCount() == 4); // The order is: id, data, value, amount
 
 		// duckdb::Value() creates a NULL value
-		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                                 // id
-		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});                       // data
-		check_row(res, 2, {"\'42\'", duckdb::Value(), "DECIMAL(17,4)"}); // value
-		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"});                 // amount
+		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                 // id
+		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});       // data
+		check_row(res, 2, {"\'42\'", duckdb::Value(), "DECIMAL(17,4)"});        // value
+		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"}); // amount
 	}
 
 	// Clean up

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -296,7 +296,7 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		// duckdb::Value() creates a NULL value
 		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                 // id
 		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});       // data
-		check_row(res, 2, {"\'42\'", duckdb::Value(), "DECIMAL(17,4)"});        // value
+		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17,4))", duckdb::Value(), "DECIMAL(17,4)"});        // value
 		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"}); // amount
 	}
 

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -602,8 +602,7 @@ TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
 		REQUIRE(res2->GetValue(0, 0).ToString() == "default_value");
 	}
 
-	// Add column with default "NULL", that should become a string "NULL", not
-	// NULL.
+	// Add column with default "NULL", that should become a string "NULL", not NULL.
 	{
 		::fivetran_sdk::v2::MigrateRequest request;
 		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
@@ -658,10 +657,33 @@ TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
 		                     " Fivetran support.");
 	}
 
+	// Adding an existing column should change the default value
+	{
+		::fivetran_sdk::v2::MigrateRequest request;
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
+		auto add_col = request.mutable_details()->mutable_add()->mutable_add_column_with_default_value();
+		add_col->set_column("new_col");
+		add_col->set_column_type(::fivetran_sdk::v2::DataType::STRING);
+		add_col->set_default_value("new_default_value");
+
+		::fivetran_sdk::v2::MigrateResponse response;
+		auto status = service.Migrate(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+	}
+
 	{
 		auto res = con->Query("INSERT INTO " + table_name + " (id) VALUES (4)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("SELECT new_col3 FROM " + table_name + " WHERE id = 4");
+		auto res2 = con->Query("SELECT new_col FROM " + table_name + " WHERE id = 4");
+		REQUIRE_NO_FAIL(res2);
+		REQUIRE(res2->RowCount() == 1);
+		REQUIRE(res2->GetValue(0, 0).ToString() == "new_default_value");
+	}
+
+	{
+		auto res = con->Query("INSERT INTO " + table_name + " (id) VALUES (5)");
+		REQUIRE_NO_FAIL(res);
+		auto res2 = con->Query("SELECT new_col3 FROM " + table_name + " WHERE id = 5");
 		REQUIRE_NO_FAIL(res2);
 		REQUIRE(res2->RowCount() == 1);
 		REQUIRE(res2->GetValue(0, 0).ToString().empty());

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -296,7 +296,7 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		// duckdb::Value() creates a NULL value
 		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                 // id
 		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});       // data
-		check_row(res, 2, {"\'42\'", duckdb::Value(), "DECIMAL(17,4)"});        // value
+		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17,4))", duckdb::Value(), "DECIMAL(17,4)"});        // value
 		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"}); // amount
 	}
 
@@ -487,7 +487,7 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 		REQUIRE(res->RowCount() == 6);
 
 		// _fivetran_active is not a pk and has a default
-		check_row(res, 0, {duckdb::Value(), "'CAST(''true'' AS BOOLEAN)'"});
+		check_row(res, 0, {duckdb::Value(), "CAST('CAST(''true'' AS BOOLEAN)' AS BOOLEAN)"});
 		check_row(res, 1, {duckdb::Value(), duckdb::Value()}); // _fivetran_end is not a pk
 		check_row(res, 2, {"PRI", duckdb::Value()});           // _fivetran_start is a pk
 		check_row(res, 3, {duckdb::Value(), duckdb::Value()}); // _fivetran_synced is not a pk


### PR DESCRIPTION
As discussed "offline", Fivetran expects AddColumnWithDefaultValue to allow columns to exist, in which case only the default value should be changed.