### PR TITLE
Fix instance where we did not pass the full table name

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -160,7 +160,7 @@ public:
 	                const std::string& log_prefix, const std::vector<const column_def*>& additional_pks = {});
 
 	// Copy a column in the destination.
-	void copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column,
+	void copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column_name,
 	                 const std::string& to_column_name);
 
 	// For a table that is in either in live- or soft-delete-mode, copy it into a
@@ -175,8 +175,8 @@ public:
 	                  const std::string& log_prefix);
 
 	// Rename a destination column
-	void rename_column(duckdb::Connection& con, const table_def& table, const std::string& from_column,
-	                   const std::string& to_column);
+	void rename_column(duckdb::Connection& con, const table_def& table, const std::string& from_column_name,
+	                   const std::string& to_column_name);
 
 	// Verify the state of the history table before performing schema migrations
 	static bool history_table_is_valid(duckdb::Connection& con, const table_def& table,

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -161,7 +161,7 @@ public:
 
 	// Copy a column in the destination.
 	void copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column,
-	                 const std::string& to_column);
+	                 const std::string& to_column_name);
 
 	// For a table that is in either in live- or soft-delete-mode, copy it into a
 	// new table in history mode. For soft-delete-mode, in which case
@@ -179,7 +179,7 @@ public:
 	                   const std::string& to_column);
 
 	// Verify the state of the history table before performing schema migrations
-	static bool history_table_is_valid(duckdb::Connection& con, const std::string& absolute_table_name,
+	static bool history_table_is_valid(duckdb::Connection& con, const table_def& table,
 	                                   const std::string& quoted_timestamp);
 
 	// Add a column in history mode, which means we copy all active tables over to
@@ -210,10 +210,10 @@ public:
 	// sync as the initial insert into the historic table.
 	void migrate_soft_delete_to_history(duckdb::Connection& con, const table_def& original_table,
 	                                    const std::string& soft_deleted_column);
-	void add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns, const std::string& table_name,
+	void add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns, const table_def& table,
 	                  const std::string& log_prefix);
-	void add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk,
-	             const std::string& table_name, const std::string& log_prefix) const;
+	void add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk, const table_def& table,
+	             const std::string& log_prefix) const;
 
 	// Switch between sync modes: history to soft-delete. This means keeping only
 	// the last entries based on per MAX("_fivetran_start") per primary key,

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -822,7 +822,7 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 
 				if (column_exists) {
 					// If the column already exists, only the default value should be changed.
-					sql_generator->add_defaults(con, {new_column}, table_name, "add_column");
+					sql_generator->add_defaults(con, {new_column}, table, "add_column");
 				} else {
 					sql_generator->add_column(con, table, new_column, "add_column");
 				}

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -1085,12 +1085,13 @@ void MdSqlGenerator::rename_column(duckdb::Connection& con, const table_def& tab
                                    const std::string& to_column_name) {
 	const std::string absolute_table_name = table.to_escaped_string();
 	std::ostringstream sql;
-	sql << "ALTER TABLE " << absolute_table_name << " RENAME COLUMN " << KeywordHelper::WriteQuoted(from_column_name, '"')
-	    << " TO " << KeywordHelper::WriteQuoted(to_column_name, '"');
+	sql << "ALTER TABLE " << absolute_table_name << " RENAME COLUMN "
+	    << KeywordHelper::WriteQuoted(from_column_name, '"') << " TO "
+	    << KeywordHelper::WriteQuoted(to_column_name, '"');
 
 	run_query(con, "rename_column", sql.str(),
-	          "Could not rename column <" + from_column_name + "> to <" + to_column_name + "> in table <" + absolute_table_name +
-	              ">");
+	          "Could not rename column <" + from_column_name + "> to <" + to_column_name + "> in table <" +
+	              absolute_table_name + ">");
 }
 
 bool MdSqlGenerator::history_table_is_valid(duckdb::Connection& con, const table_def& table,
@@ -1242,7 +1243,6 @@ void MdSqlGenerator::migrate_soft_delete_to_history(duckdb::Connection& con, con
 	const std::string quoted_deleted_col = KeywordHelper::WriteQuoted(soft_deleted_column, '"');
 
 	table_def temp_table {original_table.db_name, original_table.schema_name, original_table.table_name + "_temp"};
-	const std::string temp_absolute_table_name = temp_table.to_escaped_string();
 
 	{
 		TransactionContext transaction_context(con);

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -874,7 +874,7 @@ void MdSqlGenerator::drop_column_in_history_mode(duckdb::Connection& con, const 
 	const std::string quoted_column = KeywordHelper::WriteQuoted(column, '"');
 	const std::string quoted_timestamp = KeywordHelper::WriteQuoted(operation_timestamp, '\'') + "::TIMESTAMPTZ";
 
-	if (!history_table_is_valid(con, absolute_table_name, quoted_timestamp)) {
+	if (!history_table_is_valid(con, table, quoted_timestamp)) {
 		// The table is empty
 		return;
 	}
@@ -959,14 +959,14 @@ void MdSqlGenerator::copy_table(duckdb::Connection& con, const table_def& from_t
 	combined_pks.insert(combined_pks.end(), columns_pk.begin(), columns_pk.end());
 	combined_pks.insert(combined_pks.end(), additional_pks.begin(), additional_pks.end());
 
-	add_defaults(con, columns, to_table.to_escaped_string(), log_prefix);
-	add_pks(con, combined_pks, to_table.to_escaped_string(), log_prefix);
+	add_defaults(con, columns, to_table, log_prefix);
+	add_pks(con, combined_pks, to_table, log_prefix);
 
 	transaction_context.Commit();
 }
 
 void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns,
-                                  const std::string& table_name, const std::string& log_prefix) {
+                                  const table_def& table, const std::string& log_prefix) {
 	// Copies the default of every column that has a default defined to the destination table_name. This assumes all
 	// columns are present in the destination table.
 	for (const auto& col : columns) {
@@ -981,38 +981,38 @@ void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<col
 		// this method were generated with describe_table(). This results in e.g. "CAST(CAST(\'42\' as int) as int)"
 		// being generated. We decided that we are find with this edge-case for now since this is still a valid default
 		// and makes this method more usable.
-		sql << "ALTER TABLE " << table_name << " ALTER COLUMN " << KeywordHelper::WriteQuoted(col.name, '"')
-		    << " SET DEFAULT CAST(" << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS "
-		    << format_type(col) << ");";
+		sql << "ALTER TABLE " << table.to_escaped_string() << " ALTER COLUMN "
+		    << KeywordHelper::WriteQuoted(col.name, '"') << " SET DEFAULT CAST("
+		    << KeywordHelper::WriteQuoted(col.column_default.value(), '\'') << " AS " << format_type(col) << ");";
 
 		run_query(con, log_prefix, sql.str(), "Could not add default to column " + col.name);
 	}
 }
 
 void MdSqlGenerator::add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk,
-                             const std::string& table_name, const std::string& log_prefix) const {
+                             const table_def& table, const std::string& log_prefix) const {
 	if (columns_pk.empty()) {
 		// All modes require a primary key to be present, because we cannot switch
 		// to history mode without a primary key. Fivetran has confirmed that the
 		// partner sdk assures existence of a primary key, and else adds a primary
 		// key itself.
-		throw std::runtime_error("No primary keys found for table " + table_name);
+		throw std::runtime_error("No primary keys found for table " + table.to_escaped_string());
 	}
 
 	// Add the right primary key. Note that "CREATE TABLE AS SELECT" does not
 	// add any primary key constraints.
 	std::ostringstream sql;
 
-	sql << "ALTER TABLE " << table_name << " ADD PRIMARY KEY (";
+	sql << "ALTER TABLE " << table.to_escaped_string() << " ADD PRIMARY KEY (";
 	join(sql, columns_pk, to_name);
 	sql << ");";
-	run_query(con, log_prefix, sql.str(), "Could not add pks to table " + table_name);
+	run_query(con, log_prefix, sql.str(), "Could not add pks to table " + table.to_escaped_string());
 }
 
 void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column,
-                                 const std::string& to_name) {
+                                 const std::string& to_column_name) {
 	const std::string quoted_from = KeywordHelper::WriteQuoted(from_column, '"');
-	const std::string quoted_to = KeywordHelper::WriteQuoted(to_name, '"');
+	const std::string quoted_to = KeywordHelper::WriteQuoted(to_column_name, '"');
 
 	// Get the column type from the source column
 	auto query = "SELECT data_type_id, column_default, numeric_precision, numeric_scale "
@@ -1034,7 +1034,7 @@ void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table
 	auto type = static_cast<duckdb::LogicalTypeId>(result->GetValue(0, 0).GetValue<int8_t>());
 
 	column_def to_column {
-	    .name = to_name,
+	    .name = to_column_name,
 	    .type = type,
 	    .column_default = result->GetValue(1, 0).GetValue<duckdb::string>(),
 	};
@@ -1048,8 +1048,8 @@ void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table
 
 	add_column(con, table, to_column, "copy_column add");
 	run_query(con, "copy_column update",
-	          "UPDATE " + table.to_escaped_string() + " SET " + KeywordHelper::WriteQuoted(to_name, '"') + " = " +
-	              quoted_from,
+	          "UPDATE " + table.to_escaped_string() + " SET " + KeywordHelper::WriteQuoted(to_column_name, '"') +
+	              " = " + quoted_from,
 	          "Could not copy column values");
 
 	transaction_context.Commit();
@@ -1093,7 +1093,7 @@ void MdSqlGenerator::rename_column(duckdb::Connection& con, const table_def& tab
 	              ">");
 }
 
-bool MdSqlGenerator::history_table_is_valid(duckdb::Connection& con, const std::string& absolute_table_name,
+bool MdSqlGenerator::history_table_is_valid(duckdb::Connection& con, const table_def& table,
                                             const std::string& quoted_timestamp) {
 	// This performs the "Validation before starting the migration" part of
 	// add/drop column in history mode as specified in the docs:
@@ -1105,7 +1105,7 @@ bool MdSqlGenerator::history_table_is_valid(duckdb::Connection& con, const std::
 	// else we return true. This also allows us to cleanly redirect to performing
 	// a regular add/drop column when the table is empty.
 
-	auto result = con.Query("SELECT COUNT(*) FROM " + absolute_table_name);
+	auto result = con.Query("SELECT COUNT(*) FROM " + table.to_escaped_string());
 
 	if (result->HasError()) {
 		throw std::runtime_error("Could not query table size: " + result->GetError());
@@ -1117,7 +1117,7 @@ bool MdSqlGenerator::history_table_is_valid(duckdb::Connection& con, const std::
 	}
 
 	auto max_result = con.Query("SELECT MAX(\"_fivetran_start\") <= " + quoted_timestamp + " FROM " +
-	                            absolute_table_name + " WHERE \"_fivetran_active\" = true");
+	                            table.to_escaped_string() + " WHERE \"_fivetran_active\" = true");
 
 	if (max_result->HasError()) {
 		throw std::runtime_error("Could not query _fivetran_start value: " + max_result->GetError());
@@ -1141,7 +1141,7 @@ void MdSqlGenerator::add_column_in_history_mode(duckdb::Connection& con, const t
 	TransactionContext transaction_context(con);
 	add_column(con, table, column, "add_column_in_history_mode create");
 
-	if (!history_table_is_valid(con, absolute_table_name, quoted_timestamp)) {
+	if (!history_table_is_valid(con, table, quoted_timestamp)) {
 		// The table is empty and the column has been added
 		transaction_context.Commit();
 		return;
@@ -1364,7 +1364,7 @@ void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, con
 	                 .type = duckdb::LogicalTypeId::BOOLEAN,
 	                 .column_default = "false",
 	             }},
-	             temp_table_name, "migrate_history_to_soft_delete set_deleted_default");
+	             temp_table, "migrate_history_to_soft_delete set_deleted_default");
 
 	// _fivetran_start, _fivetran_end and _fivetran_active are not present in temp_table.
 	std::vector<column_def> new_columns;
@@ -1373,8 +1373,8 @@ void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, con
 			new_columns.push_back(col);
 		}
 	}
-	add_defaults(con, new_columns, temp_table_name, "migrate_history_to_soft_delete set_default");
-	add_pks(con, columns_pk, temp_table_name, "migrate_history_to_soft_delete set_pk");
+	add_defaults(con, new_columns, temp_table, "migrate_history_to_soft_delete set_default");
+	add_pks(con, columns_pk, temp_table, "migrate_history_to_soft_delete set_pk");
 
 	// Swap the original and temporary table
 	drop_table(con, table, "migrate_history_to_soft_delete drop");
@@ -1425,10 +1425,10 @@ void MdSqlGenerator::migrate_history_to_live(duckdb::Connection& con, const tabl
 			new_columns.push_back(col);
 		}
 	}
-	add_defaults(con, new_columns, temp_table_name, "migrate_history_to_live set_default");
+	add_defaults(con, new_columns, temp_table, "migrate_history_to_live set_default");
 
 	if (!keep_deleted_rows) {
-		add_pks(con, columns_pk, temp_table_name, "migrate_history_to_live add_pks");
+		add_pks(con, columns_pk, temp_table, "migrate_history_to_live add_pks");
 	}
 
 	// Swap the original and temporary table

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -1009,9 +1009,9 @@ void MdSqlGenerator::add_pks(duckdb::Connection& con, const std::vector<const co
 	run_query(con, log_prefix, sql.str(), "Could not add pks to table " + table.to_escaped_string());
 }
 
-void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column,
+void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column_name,
                                  const std::string& to_column_name) {
-	const std::string quoted_from = KeywordHelper::WriteQuoted(from_column, '"');
+	const std::string quoted_from = KeywordHelper::WriteQuoted(from_column_name, '"');
 	const std::string quoted_to = KeywordHelper::WriteQuoted(to_column_name, '"');
 
 	// Get the column type from the source column
@@ -1021,7 +1021,7 @@ void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table
 	             KeywordHelper::WriteQuoted(table.db_name, '\'') +
 	             " AND schema_name = " + KeywordHelper::WriteQuoted(table.schema_name, '\'') +
 	             " AND table_name = " + KeywordHelper::WriteQuoted(table.table_name, '\'') +
-	             " AND column_name = " + KeywordHelper::WriteQuoted(from_column, '\'');
+	             " AND column_name = " + KeywordHelper::WriteQuoted(from_column_name, '\'');
 	auto result = con.Query(query);
 
 	if (result->HasError()) {
@@ -1081,15 +1081,15 @@ void MdSqlGenerator::rename_table(duckdb::Connection& con, const table_def& from
 	run_query(con, log_prefix, sql.str(), "Could not rename table <" + from_table.to_escaped_string() + ">");
 }
 
-void MdSqlGenerator::rename_column(duckdb::Connection& con, const table_def& table, const std::string& from_column,
-                                   const std::string& to_column) {
+void MdSqlGenerator::rename_column(duckdb::Connection& con, const table_def& table, const std::string& from_column_name,
+                                   const std::string& to_column_name) {
 	const std::string absolute_table_name = table.to_escaped_string();
 	std::ostringstream sql;
-	sql << "ALTER TABLE " << absolute_table_name << " RENAME COLUMN " << KeywordHelper::WriteQuoted(from_column, '"')
-	    << " TO " << KeywordHelper::WriteQuoted(to_column, '"');
+	sql << "ALTER TABLE " << absolute_table_name << " RENAME COLUMN " << KeywordHelper::WriteQuoted(from_column_name, '"')
+	    << " TO " << KeywordHelper::WriteQuoted(to_column_name, '"');
 
 	run_query(con, "rename_column", sql.str(),
-	          "Could not rename column <" + from_column + "> to <" + to_column + "> in table <" + absolute_table_name +
+	          "Could not rename column <" + from_column_name + "> to <" + to_column_name + "> in table <" + absolute_table_name +
 	              ">");
 }
 

--- a/test/constants.cpp
+++ b/test/constants.cpp
@@ -30,5 +30,6 @@ std::string get_motherduck_auth_token() {
 } // namespace
 
 const std::string TEST_DATABASE_NAME = get_randomized_test_database_name();
+const std::string TEST_SCHEMA_NAME = "test_schema";
 const std::string MD_TOKEN = get_motherduck_auth_token();
 } // namespace test::constants

--- a/test/constants.hpp
+++ b/test/constants.hpp
@@ -10,6 +10,7 @@ const std::string TEST_RESOURCES_DIR = XSTRING(TEST_RESOURCES_LOCATION);
 #undef STRING
 
 extern const std::string TEST_DATABASE_NAME;
+extern const std::string TEST_SCHEMA_NAME;
 
 extern const std::string MD_TOKEN;
 } // namespace test::constants

--- a/test/integration/common.hpp
+++ b/test/integration/common.hpp
@@ -160,6 +160,7 @@ void add_config(T& request, const std::string& token, const std::string& databas
 	(*request.mutable_configuration())["motherduck_token"] = token;
 	(*request.mutable_configuration())["motherduck_database"] = database;
 	request.mutable_table()->set_name(table);
+	request.set_schema_name(test::constants::TEST_SCHEMA_NAME);
 }
 
 inline void add_config(fivetran_sdk::v2::MigrateRequest& request, const std::string& token, const std::string& database,
@@ -167,6 +168,7 @@ inline void add_config(fivetran_sdk::v2::MigrateRequest& request, const std::str
 	(*request.mutable_configuration())["motherduck_token"] = token;
 	(*request.mutable_configuration())["motherduck_database"] = database;
 	request.mutable_details()->set_table(table);
+	request.mutable_details()->set_schema(test::constants::TEST_SCHEMA_NAME);
 }
 
 template <typename T>
@@ -176,12 +178,14 @@ void add_config(T& request, const std::string& token, const std::string& databas
 	(*request.mutable_configuration())["motherduck_token"] = token;
 	(*request.mutable_configuration())["motherduck_database"] = database;
 	request.set_table_name(table);
+	request.set_schema_name(test::constants::TEST_SCHEMA_NAME);
 }
 
 template <typename T>
 void add_config(T& request, const std::string& token, const std::string& database) {
 	(*request.mutable_configuration())["motherduck_token"] = token;
 	(*request.mutable_configuration())["motherduck_database"] = database;
+	request.set_schema_name(test::constants::TEST_SCHEMA_NAME);
 }
 
 // Same columns as define_history_test_table but in a DIFFERENT order.

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -294,10 +294,10 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		REQUIRE(res->RowCount() == 4); // The order is: id, data, value, amount
 
 		// duckdb::Value() creates a NULL value
-		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                 // id
-		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});       // data
-		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17,4))", duckdb::Value(), "DECIMAL(17,4)"});        // value
-		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"}); // amount
+		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                                 // id
+		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});                       // data
+		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17,4))", duckdb::Value(), "DECIMAL(17,4)"}); // value
+		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"});                 // amount
 	}
 
 	// Clean up

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -26,12 +26,12 @@ TEST_CASE("Migrate - drop table", "[integration][migrate]") {
 
 	auto con = get_test_connection(MD_TOKEN);
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'Alice')");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'Alice')");
 		REQUIRE_NO_FAIL(res);
 	}
 
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + table_name);
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 1);
 	}
@@ -63,7 +63,8 @@ TEST_CASE("Migrate - drop table", "[integration][migrate]") {
 		::fivetran_sdk::v2::MigrateResponse response;
 		auto status = service.Migrate(nullptr, &request, &response);
 		REQUIRE_FAIL(status, Catch::Matchers::ContainsSubstring("Could not drop table <\"" + TEST_DATABASE_NAME +
-		                                                        "\".\"main\".\"fake_table_name\">: "
+		                                                        "\".\"" + TEST_SCHEMA_NAME +
+		                                                        "\".\"fake_table_name\">: "
 		                                                        "Catalog Error: Table with name fake_table_name "
 		                                                        "does not exist!\n"));
 	}
@@ -80,7 +81,7 @@ TEST_CASE("Migrate - rename table", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + from_table + " VALUES (1, 'test_data')");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + from_table + " VALUES (1, 'test_data')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -105,7 +106,7 @@ TEST_CASE("Migrate - rename table", "[integration][migrate]") {
 
 	// Verify new table exists with data
 	{
-		auto res = con->Query("SELECT value FROM " + to_table + " WHERE id = 1");
+		auto res = con->Query("SELECT value FROM " + TEST_SCHEMA_NAME + "." + to_table + " WHERE id = 1");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0).ToString() == "test_data");
@@ -120,10 +121,11 @@ TEST_CASE("Migrate - rename table", "[integration][migrate]") {
 
 		::fivetran_sdk::v2::MigrateResponse response;
 		auto status = service.Migrate(nullptr, &request, &response);
-		REQUIRE_FAIL(status, Catch::Matchers::ContainsSubstring("Could not rename table <\"" + TEST_DATABASE_NAME +
-		                                                        "\".\"main\".\"fake_table_name\">: " +
-		                                                        "Catalog Error: Table with name fake_table_name "
-		                                                        "does not exist!\n"));
+		REQUIRE_FAIL(status,
+		             Catch::Matchers::ContainsSubstring("Could not rename table <\"" + TEST_DATABASE_NAME + "\".\"" +
+		                                                TEST_SCHEMA_NAME + "\".\"fake_table_name\">: " +
+		                                                "Catalog Error: Table with name fake_table_name "
+		                                                "does not exist!\n"));
 	}
 
 	// Create another source table
@@ -138,9 +140,9 @@ TEST_CASE("Migrate - rename table", "[integration][migrate]") {
 
 		::fivetran_sdk::v2::MigrateResponse response;
 		auto status = service.Migrate(nullptr, &request, &response);
-		REQUIRE_FAIL(status, "Could not rename table <\"" + TEST_DATABASE_NAME + "\".\"main\".\"" + second_from_table +
-		                         "\">: Catalog Error: Could not rename \"" + second_from_table + "\" to \"" + to_table +
-		                         "\": another entry with this name already exists!");
+		REQUIRE_FAIL(status, "Could not rename table <\"" + TEST_DATABASE_NAME + "\".\"" + TEST_SCHEMA_NAME + "\".\"" +
+		                         second_from_table + "\">: Catalog Error: Could not rename \"" + second_from_table +
+		                         "\" to \"" + to_table + "\": another entry with this name already exists!");
 	}
 
 	// Clean up
@@ -156,7 +158,7 @@ TEST_CASE("Migrate - rename column", "[integration][migrate]") {
 	auto con = get_test_connection(MD_TOKEN);
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'test_value')");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'test_value')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -175,7 +177,7 @@ TEST_CASE("Migrate - rename column", "[integration][migrate]") {
 
 	// Verify column was renamed and data preserved
 	{
-		auto res = con->Query("SELECT new_name FROM " + table_name + " WHERE id = 1");
+		auto res = con->Query("SELECT new_name FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE id = 1");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0).ToString() == "test_value");
@@ -183,7 +185,7 @@ TEST_CASE("Migrate - rename column", "[integration][migrate]") {
 
 	// Verify old column name doesn't work
 	{
-		auto res = con->Query("SELECT old_name FROM " + table_name);
+		auto res = con->Query("SELECT old_name FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 		REQUIRE_THAT(res->GetError(),
 		             Catch::Matchers::ContainsSubstring("Binder Error: Referenced column \"old_name\" not found "
@@ -201,8 +203,8 @@ TEST_CASE("Migrate - rename column", "[integration][migrate]") {
 		auto status = service.Migrate(nullptr, &request, &response);
 		REQUIRE_FAIL(status, "Could not rename column <fake_column_name> to "
 		                     "<another_new_name> in table <\"" +
-		                         TEST_DATABASE_NAME + "\".\"main\".\"" + table_name + "\">: Binder Error: Table \"" +
-		                         table_name +
+		                         TEST_DATABASE_NAME + "\".\"" + TEST_SCHEMA_NAME + "\".\"" + table_name +
+		                         "\">: Binder Error: Table \"" + table_name +
 		                         "\" does not have a column with name "
 		                         "\"fake_column_name\"\n\nDid you mean: \"new_name\"");
 	}
@@ -216,8 +218,8 @@ TEST_CASE("Migrate - rename column", "[integration][migrate]") {
 
 		::fivetran_sdk::v2::MigrateResponse response;
 		auto status = service.Migrate(nullptr, &request, &response);
-		REQUIRE_FAIL(status, "Could not rename column <id> to <new_name> in table <\"" + TEST_DATABASE_NAME +
-		                         "\".\"main\".\"" + table_name +
+		REQUIRE_FAIL(status, "Could not rename column <id> to <new_name> in table <\"" + TEST_DATABASE_NAME + "\".\"" +
+		                         TEST_SCHEMA_NAME + "\".\"" + table_name +
 		                         "\">: Catalog Error: Column with name new_name already exists!");
 	}
 
@@ -236,7 +238,7 @@ TEST_CASE("Migrate - rename column", "[integration][migrate]") {
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - copy table", "[integration][migrate]") {
@@ -248,7 +250,7 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 
 	// Create the source table
 	{
-		auto res = con->Query("CREATE TABLE " + from_table +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + from_table +
 		                      " (id INT, data VARCHAR, value DECIMAL(17,4) default "
 		                      "42, amount DECIMAL(31,6), primary key (id))");
 		REQUIRE_NO_FAIL(res);
@@ -256,7 +258,8 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + from_table + " VALUES (1, 'data1', 3.1415, 3), (2, 'data2', 10.0, 49)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + from_table +
+		                      " VALUES (1, 'data1', 3.1415, 3), (2, 'data2', 10.0, 49)");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -275,12 +278,12 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 
 	// Verify both tables exist with correct data
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + from_table);
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + from_table);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 2);
 	}
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + to_table);
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + to_table);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 2);
 	}
@@ -288,8 +291,7 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 	// Check decimal precision
 
 	{
-		auto res = con->Query("SELECT \"default\", key, column_type FROM (describe " +
-		                      duckdb::KeywordHelper::WriteQuoted(to_table, '\'') + ")");
+		auto res = con->Query("SELECT \"default\", key, column_type FROM (describe " + TEST_SCHEMA_NAME + "." + to_table + ")");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 4); // The order is: id, data, value, amount
 
@@ -301,8 +303,8 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + from_table);
-	con->Query("DROP TABLE IF EXISTS " + to_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + from_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + to_table);
 }
 
 TEST_CASE("Migrate - copy column", "[integration][migrate]") {
@@ -314,7 +316,7 @@ TEST_CASE("Migrate - copy column", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'original')");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'original')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -333,7 +335,8 @@ TEST_CASE("Migrate - copy column", "[integration][migrate]") {
 
 	// Verify both columns exist with same data
 	{
-		auto res = con->Query("SELECT source_col, dest_col FROM " + table_name + " WHERE id = 1");
+		auto res =
+		    con->Query("SELECT source_col, dest_col FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE id = 1");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		check_row(res, 0, {"original", "original"});
@@ -363,7 +366,7 @@ TEST_CASE("Migrate - copy column", "[integration][migrate]") {
 
 		REQUIRE_FAIL(status, "Could not add column <dest_col> to table "
 		                     "<\"" +
-		                         TEST_DATABASE_NAME + "\".\"main\".\"" + table_name +
+		                         TEST_DATABASE_NAME + "\".\"" + TEST_SCHEMA_NAME + "\".\"" + table_name +
 		                         "\">: "
 		                         "Catalog Error: Column with name dest_col already exists!");
 	}
@@ -395,30 +398,31 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Create source table with soft delete column
-	con->Query("DROP TABLE IF EXISTS " + source_table);
-	con->Query("DROP TABLE IF EXISTS " + dest_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + source_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + dest_table);
 	{
-		auto res = con->Query("CREATE TABLE " + source_table +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + source_table +
 		                      " (id INT, name VARCHAR, _fivetran_deleted BOOLEAN, "
 		                      "_fivetran_synced TIMESTAMPTZ, primary key (id))");
 		REQUIRE_NO_FAIL(res);
 
 		if (soft_deleted_column != "_fivetran_deleted") {
-			auto res2 = con->Query("ALTER TABLE " + source_table + " ADD COLUMN " + soft_deleted_column + " BOOLEAN");
+			auto res2 = con->Query("ALTER TABLE " + TEST_SCHEMA_NAME + "." + source_table + " ADD COLUMN " +
+			                       soft_deleted_column + " BOOLEAN");
 			REQUIRE_NO_FAIL(res2);
 		}
 	}
 
 	// Insert data with some deleted rows
 	if (soft_deleted_column != "_fivetran_deleted") {
-		auto res = con->Query("INSERT INTO " + source_table + " (id, name, _fivetran_deleted, _fivetran_synced, " +
-		                      soft_deleted_column +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + source_table +
+		                      " (id, name, _fivetran_deleted, _fivetran_synced, " + soft_deleted_column +
 		                      ") VALUES (1, 'Alice', false, NOW(), false), "
 		                      "(2, 'Bob', true, NOW(), true), "
 		                      "(3, 'Charlie', false, NOW(), false)");
 		REQUIRE_NO_FAIL(res);
 	} else {
-		auto res = con->Query("INSERT INTO " + source_table +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + source_table +
 		                      " (id, name, _fivetran_deleted, _fivetran_synced) "
 		                      "VALUES (1, 'Alice', false, NOW()), "
 		                      "(2, 'Bob', true, NOW()), "
@@ -443,7 +447,7 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 
 	// Verify destination table has history columns
 	{
-		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + dest_table + " ORDER BY id");
+		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + dest_table + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		// Alice (not deleted) -> active
@@ -454,16 +458,15 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 		REQUIRE(res->GetValue(2, 2) == true);
 	}
 
-	// Verify soft_deleted_column is NOT in the destination when it's the
-	// "_fivetran_deleted" column
+	// Verify soft_deleted_column is NOT in the destination when it's the "_fivetran_deleted" column
 	if (soft_deleted_column == "_fivetran_deleted") {
-		auto res = con->Query("SELECT " + soft_deleted_column + " FROM " + dest_table);
+		auto res = con->Query("SELECT " + soft_deleted_column + " FROM " + TEST_SCHEMA_NAME + "." + dest_table);
 		REQUIRE(res->HasError());
 	} else {
 		// We want check here that soft_deleted_column is not a PK, so we can ignore
 		// this column when we verify the whole PK below
-		auto res = con->Query("SELECT key FROM (describe " + duckdb::KeywordHelper::WriteQuoted(dest_table, '\'') +
-		                      ") WHERE column_name = \'" + soft_deleted_column + "\'");
+		auto res = con->Query("SELECT key FROM (describe " + TEST_SCHEMA_NAME + "." + dest_table + ") WHERE column_name = \'" +
+		                      soft_deleted_column + "\'");
 		REQUIRE_NO_FAIL(res);
 
 		// soft_deleted_column is not a pk
@@ -472,15 +475,14 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 
 	// Verify history columns exist
 	{
-		auto res = con->Query("SELECT _fivetran_start, _fivetran_end FROM " + dest_table);
+		auto res = con->Query("SELECT _fivetran_start, _fivetran_end FROM " + TEST_SCHEMA_NAME + "." + dest_table);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}
 
 	// Verify id is part of primary key and defaults are set
 	{
-		auto res = con->Query("SELECT key, \"default\" FROM (describe " +
-		                      duckdb::KeywordHelper::WriteQuoted(dest_table, '\'') + ") WHERE column_name != \'" +
+		auto res = con->Query("SELECT key, \"default\" FROM (describe " + TEST_SCHEMA_NAME + "." + dest_table + ") WHERE column_name != \'" +
 		                      soft_deleted_column + "\' ORDER BY column_name");
 		REQUIRE_NO_FAIL(res);
 		// The order is: _fivetran_active, _fivetran_end, _fivetran_start, _fivetran_synced, id, name
@@ -496,8 +498,8 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + source_table);
-	con->Query("DROP TABLE IF EXISTS " + dest_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + source_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + dest_table);
 }
 
 TEST_CASE("Migrate - copy table to history mode from live", "[integration][migrate]") {
@@ -508,16 +510,18 @@ TEST_CASE("Migrate - copy table to history mode from live", "[integration][migra
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Create source table (live mode - no soft delete column)
-	con->Query("DROP TABLE IF EXISTS " + source_table);
-	con->Query("DROP TABLE IF EXISTS " + dest_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + source_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + dest_table);
 	{
-		auto res = con->Query("CREATE TABLE " + source_table + " (id INT, name VARCHAR, primary key (id))");
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + source_table +
+		                      " (id INT, name VARCHAR, primary key (id))");
 		REQUIRE_NO_FAIL(res);
 	}
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + source_table + " VALUES (1, 'Alice'), (2, 'Bob')");
+		auto res =
+		    con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + source_table + " VALUES (1, 'Alice'), (2, 'Bob')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -538,7 +542,8 @@ TEST_CASE("Migrate - copy table to history mode from live", "[integration][migra
 
 	// Verify destination table has history columns and all rows are active
 	{
-		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + dest_table + " ORDER BY id");
+		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + dest_table +
+		                      " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		// All rows should be active (live mode)
@@ -548,21 +553,21 @@ TEST_CASE("Migrate - copy table to history mode from live", "[integration][migra
 
 	// Verify history columns exist with proper values
 	{
-		auto res = con->Query("SELECT _fivetran_end FROM " + dest_table +
+		auto res = con->Query("SELECT _fivetran_end FROM " + TEST_SCHEMA_NAME + "." + dest_table +
 		                      " WHERE _fivetran_end = '9999-12-31T23:59:59.999Z'::TIMESTAMPTZ");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 	}
 	{
-		auto res = con->Query("SELECT _fivetran_start FROM " + dest_table +
+		auto res = con->Query("SELECT _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + dest_table +
 		                      " WHERE _fivetran_start BETWEEN 'epoch'::TIMESTAMPTZ AND NOW();");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + source_table);
-	con->Query("DROP TABLE IF EXISTS " + dest_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + source_table);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + dest_table);
 }
 
 TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
@@ -574,7 +579,7 @@ TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1)");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -594,9 +599,9 @@ TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
 	}
 
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " (id) VALUES (2)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " (id) VALUES (2)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("SELECT new_col FROM " + table_name + " WHERE id = 2");
+		auto res2 = con->Query("SELECT new_col FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE id = 2");
 		REQUIRE_NO_FAIL(res2);
 		REQUIRE(res2->RowCount() == 1);
 		REQUIRE(res2->GetValue(0, 0).ToString() == "default_value");
@@ -618,9 +623,9 @@ TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
 	}
 
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " (id) VALUES (3)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " (id) VALUES (3)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("SELECT new_col2 FROM " + table_name + " WHERE id = 3");
+		auto res2 = con->Query("SELECT new_col2 FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE id = 3");
 		REQUIRE_NO_FAIL(res2);
 		REQUIRE(res2->RowCount() == 1);
 		REQUIRE(!res2->GetValue(0, 0).IsNull());
@@ -672,25 +677,25 @@ TEST_CASE("Migrate - add column with default value", "[integration][migrate]") {
 	}
 
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " (id) VALUES (4)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " (id) VALUES (4)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("SELECT new_col FROM " + table_name + " WHERE id = 4");
+		auto res2 = con->Query("SELECT new_col FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE id = 4");
 		REQUIRE_NO_FAIL(res2);
 		REQUIRE(res2->RowCount() == 1);
 		REQUIRE(res2->GetValue(0, 0).ToString() == "new_default_value");
 	}
 
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " (id) VALUES (5)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " (id) VALUES (5)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("SELECT new_col3 FROM " + table_name + " WHERE id = 5");
+		auto res2 = con->Query("SELECT new_col3 FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE id = 5");
 		REQUIRE_NO_FAIL(res2);
 		REQUIRE(res2->RowCount() == 1);
 		REQUIRE(res2->GetValue(0, 0).ToString().empty());
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - update column value", "[integration][migrate]") {
@@ -702,7 +707,8 @@ TEST_CASE("Migrate - update column value", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'old'), (2, 'old'), (3, 'old')");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " VALUES (1, 'old'), (2, 'old'), (3, 'old')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -721,7 +727,8 @@ TEST_CASE("Migrate - update column value", "[integration][migrate]") {
 
 	// Verify all rows updated
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + table_name + " WHERE status = 'updated'");
+		auto res =
+		    con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE status = 'updated'");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 3);
 	}
@@ -741,7 +748,7 @@ TEST_CASE("Migrate - update column value", "[integration][migrate]") {
 
 	// Verify all rows updated
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + table_name + " WHERE status is NULL");
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE status is NULL");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 3);
 	}
@@ -759,7 +766,7 @@ TEST_CASE("Migrate - add column in history mode", "[integration][migrate]") {
 	// Create a history table manually
 	con->Query("DROP TABLE IF EXISTS " + table_name);
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT, name VARCHAR, "
 		                      "_fivetran_start TIMESTAMPTZ, "
 		                      "_fivetran_end TIMESTAMPTZ, "
@@ -770,7 +777,7 @@ TEST_CASE("Migrate - add column in history mode", "[integration][migrate]") {
 
 	// Insert active row
 	{
-		auto res = con->Query("INSERT INTO " + table_name +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " VALUES (1, 'Alice', '2024-01-01'::TIMESTAMPTZ, "
 		                      "'9999-12-31T23:59:59.999Z'::TIMESTAMPTZ, true)");
 		REQUIRE_NO_FAIL(res);
@@ -840,14 +847,15 @@ TEST_CASE("Migrate - add column in history mode", "[integration][migrate]") {
 
 	// Verify: should have 3 rows now (old inactive + new active)
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + table_name);
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 3);
 	}
 
 	// Verify: new active row has the new columns with default values
 	{
-		auto res = con->Query("SELECT age, switch, final FROM " + table_name + " WHERE _fivetran_active = TRUE");
+		auto res = con->Query("SELECT age, switch, final FROM " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " WHERE _fivetran_active = TRUE");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		check_row(res, 0, {25, false, "NULL"});
@@ -856,7 +864,7 @@ TEST_CASE("Migrate - add column in history mode", "[integration][migrate]") {
 
 	// Verify: old row is now inactive
 	{
-		auto res = con->Query("SELECT _fivetran_active FROM " + table_name +
+		auto res = con->Query("SELECT _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " WHERE _fivetran_start = '2024-01-01'::TIMESTAMPTZ");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
@@ -864,7 +872,7 @@ TEST_CASE("Migrate - add column in history mode", "[integration][migrate]") {
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - add/drop column in history mode to empty table", "[integration][migrate]") {
@@ -874,9 +882,9 @@ TEST_CASE("Migrate - add/drop column in history mode to empty table", "[integrat
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Create a history table manually
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT, name VARCHAR, "
 		                      "_fivetran_start TIMESTAMPTZ, "
 		                      "_fivetran_end TIMESTAMPTZ, "
@@ -902,7 +910,7 @@ TEST_CASE("Migrate - add/drop column in history mode to empty table", "[integrat
 	}
 
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + table_name);
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 0);
 	}
@@ -924,13 +932,13 @@ TEST_CASE("Migrate - add/drop column in history mode to empty table", "[integrat
 	{
 		// This asserts the column still exists and the fact that the table is empty
 		// at the same time
-		auto res = con->Query("SELECT name FROM " + table_name);
+		auto res = con->Query("SELECT name FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 0);
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - drop column in history mode", "[integration][migrate]") {
@@ -940,9 +948,9 @@ TEST_CASE("Migrate - drop column in history mode", "[integration][migrate]") {
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Create a history table manually with an extra column
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT, name VARCHAR, email VARCHAR, "
 		                      "_fivetran_start TIMESTAMPTZ, "
 		                      "_fivetran_end TIMESTAMPTZ, "
@@ -953,7 +961,7 @@ TEST_CASE("Migrate - drop column in history mode", "[integration][migrate]") {
 
 	// Insert active row
 	{
-		auto res = con->Query("INSERT INTO " + table_name +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " VALUES (1, 'Alice', 'alice@example.com', '2024-01-01'::TIMESTAMPTZ, "
 		                      "'9999-12-31T23:59:59.999Z'::TIMESTAMPTZ, true)");
 		REQUIRE_NO_FAIL(res);
@@ -975,14 +983,15 @@ TEST_CASE("Migrate - drop column in history mode", "[integration][migrate]") {
 
 	// Verify: should have 2 rows now (old inactive + new active)
 	{
-		auto res = con->Query("SELECT COUNT(*) FROM " + table_name);
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0) == 2);
 	}
 
 	// Verify: new active row has NULL for the dropped column
 	{
-		auto res = con->Query("SELECT email FROM " + table_name + " WHERE _fivetran_active = TRUE");
+		auto res =
+		    con->Query("SELECT email FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE _fivetran_active = TRUE");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0).IsNull());
@@ -990,7 +999,7 @@ TEST_CASE("Migrate - drop column in history mode", "[integration][migrate]") {
 
 	// Verify: old row is now inactive but still has email value
 	{
-		auto res = con->Query("SELECT email, _fivetran_active FROM " + table_name +
+		auto res = con->Query("SELECT email, _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " WHERE _fivetran_start = '2024-01-01'::TIMESTAMPTZ");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
@@ -998,7 +1007,7 @@ TEST_CASE("Migrate - drop column in history mode", "[integration][migrate]") {
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - live to soft delete", "[integration][migrate]") {
@@ -1011,7 +1020,8 @@ TEST_CASE("Migrate - live to soft delete", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'Alice'), (2, 'Bob')");
+		auto res =
+		    con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'Alice'), (2, 'Bob')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -1031,7 +1041,8 @@ TEST_CASE("Migrate - live to soft delete", "[integration][migrate]") {
 
 	// Verify _fivetran_deleted column exists and all rows are not deleted
 	{
-		auto res = con->Query("SELECT id, _fivetran_deleted FROM " + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT id, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(1, 0) == false);
@@ -1039,7 +1050,7 @@ TEST_CASE("Migrate - live to soft delete", "[integration][migrate]") {
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - soft delete to live", "[integration][migrate]") {
@@ -1050,7 +1061,7 @@ TEST_CASE("Migrate - soft delete to live", "[integration][migrate]") {
 
 	// Create a table with soft delete column
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT PRIMARY KEY, name VARCHAR, "
 		                      "_fivetran_deleted BOOLEAN)");
 		REQUIRE_NO_FAIL(res);
@@ -1058,7 +1069,7 @@ TEST_CASE("Migrate - soft delete to live", "[integration][migrate]") {
 
 	// Insert data with some deleted rows
 	{
-		auto res = con->Query("INSERT INTO " + table_name +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " VALUES (1, 'Alice', false), "
 		                      "(2, 'Bob', true), "
 		                      "(3, 'Charlie', false)");
@@ -1081,7 +1092,7 @@ TEST_CASE("Migrate - soft delete to live", "[integration][migrate]") {
 
 	// Verify deleted row is gone
 	{
-		auto res = con->Query("SELECT id, name FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, name FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == 1);
@@ -1090,12 +1101,12 @@ TEST_CASE("Migrate - soft delete to live", "[integration][migrate]") {
 
 	// Verify _fivetran_deleted column is gone
 	{
-		auto res = con->Query("SELECT _fivetran_deleted FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - live to history", "[integration][migrate]") {
@@ -1108,7 +1119,7 @@ TEST_CASE("Migrate - live to history", "[integration][migrate]") {
 
 	// Insert data
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'initial')");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'initial')");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -1128,7 +1139,7 @@ TEST_CASE("Migrate - live to history", "[integration][migrate]") {
 	{
 		auto res = con->Query("SELECT id, value, _fivetran_start, _fivetran_end, "
 		                      "_fivetran_active FROM " +
-		                      table_name);
+		                      TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0) == 1);
@@ -1139,7 +1150,7 @@ TEST_CASE("Migrate - live to history", "[integration][migrate]") {
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - history to live", "[integration][migrate]") {
@@ -1149,9 +1160,9 @@ TEST_CASE("Migrate - history to live", "[integration][migrate]") {
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Drop and create a history table manually (no primary key to allow duplicate ids)
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT, value VARCHAR, "
 		                      "_fivetran_start TIMESTAMPTZ, "
 		                      "_fivetran_end TIMESTAMPTZ, "
@@ -1163,7 +1174,7 @@ TEST_CASE("Migrate - history to live", "[integration][migrate]") {
 	// Insert data with active and inactive records (same id can appear multiple
 	// times in history)
 	{
-		auto res = con->Query("INSERT INTO " + table_name +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " VALUES (1, 'current', NOW(), '9999-12-31 "
 		                      "23:59:59'::TIMESTAMPTZ, true),"
 		                      "(1, 'old', '2020-01-01'::TIMESTAMPTZ, NOW(), false),"
@@ -1186,7 +1197,7 @@ TEST_CASE("Migrate - history to live", "[integration][migrate]") {
 
 	// Verify only active record remains
 	{
-		auto res = con->Query("SELECT id, value FROM " + table_name);
+		auto res = con->Query("SELECT id, value FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		check_row(res, 0, {1, "current"});
@@ -1194,12 +1205,12 @@ TEST_CASE("Migrate - history to live", "[integration][migrate]") {
 
 	// Verify history columns are gone
 	{
-		auto res = con->Query("SELECT _fivetran_start FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - history to soft delete", "[integration][migrate]") {
@@ -1209,9 +1220,9 @@ TEST_CASE("Migrate - history to soft delete", "[integration][migrate]") {
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Drop and create a history table manually (no primary key to allow duplicate ids)
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT, id2 INT, value VARCHAR default 'abc', "
 		                      "_fivetran_start TIMESTAMPTZ, "
 		                      "_fivetran_end TIMESTAMPTZ, "
@@ -1222,7 +1233,7 @@ TEST_CASE("Migrate - history to soft delete", "[integration][migrate]") {
 
 	// Insert data with active and inactive records
 	{
-		auto res = con->Query("INSERT INTO " + table_name +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " VALUES (1, 1, 'active_row', NOW(), '9999-12-31 "
 		                      "23:59:59'::TIMESTAMPTZ, true),"
 		                      "(1, 1, 'inactive_row', '2020-01-01'::TIMESTAMPTZ, NOW(), false), "
@@ -1247,7 +1258,8 @@ TEST_CASE("Migrate - history to soft delete", "[integration][migrate]") {
 
 	// Verify _fivetran_deleted column exists with correct values
 	{
-		auto res = con->Query("SELECT id, value, _fivetran_deleted FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, value, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(2, 0) == false); // id=1 was active, so not deleted
@@ -1256,24 +1268,24 @@ TEST_CASE("Migrate - history to soft delete", "[integration][migrate]") {
 
 	// Verify history columns are gone
 	{
-		auto res = con->Query("SELECT _fivetran_start FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 		CHECK_THAT(res->GetError(), Catch::Matchers::ContainsSubstring("\"_fivetran_start\" not found in FROM clause"));
 	}
 	{
-		auto res = con->Query("SELECT _fivetran_end FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_end FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 		CHECK_THAT(res->GetError(), Catch::Matchers::ContainsSubstring("\"_fivetran_end\" not found in FROM clause"));
 	}
 	{
-		auto res = con->Query("SELECT _fivetran_active FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 		CHECK_THAT(res->GetError(),
 		           Catch::Matchers::ContainsSubstring("\"_fivetran_active\" not found in FROM clause"));
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - history to soft delete with custom soft deleted column", "[integration][migrate]") {
@@ -1284,7 +1296,7 @@ TEST_CASE("Migrate - history to soft delete with custom soft deleted column", "[
 
 	// Create a history table with a pre-existing custom column
 	{
-		auto res = con->Query("CREATE TABLE " + table_name +
+		auto res = con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " (id INT, value VARCHAR, is_removed BOOLEAN, "
 		                      "_fivetran_start TIMESTAMPTZ, "
 		                      "_fivetran_end TIMESTAMPTZ, "
@@ -1296,7 +1308,7 @@ TEST_CASE("Migrate - history to soft delete with custom soft deleted column", "[
 	// Insert data: two versions of id=1 (one active, one inactive), id=2 inactive and deleted. Note that in soft delete
 	// mode, we ignore the timestamps.
 	{
-		auto res = con->Query("INSERT INTO " + table_name +
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " VALUES "
 		                      "(1, 'active_row', false, NOW(), '9999-12-31 23:59:59'::TIMESTAMPTZ, true),"
 		                      "(1, 'inactive_row', false, '2020-01-01'::TIMESTAMPTZ, NOW(), false),"
@@ -1320,7 +1332,8 @@ TEST_CASE("Migrate - history to soft delete with custom soft deleted column", "[
 
 	// Verify is_removed is set based on _fivetran_active (only latest records kept)
 	{
-		auto res = con->Query("SELECT id, value, is_removed FROM " + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT id, value, is_removed FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		check_row(res, 0, {1, "active_row", false}); // id=1 had an active row
@@ -1329,16 +1342,16 @@ TEST_CASE("Migrate - history to soft delete with custom soft deleted column", "[
 
 	// Verify history columns are gone
 	{
-		auto res = con->Query("SELECT _fivetran_start FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 	}
 	{
-		auto res = con->Query("SELECT _fivetran_active FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - soft delete to history", "[integration][migrate]") {
@@ -1349,10 +1362,10 @@ TEST_CASE("Migrate - soft delete to history", "[integration][migrate]") {
 
 	// Create a table with soft delete column
 	con->BeginTransaction();
-	con->Query("CREATE TABLE " + table_name +
+	con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 	           " (id INT PRIMARY KEY, name VARCHAR, "
 	           "_fivetran_deleted BOOLEAN, _fivetran_synced TIMESTAMPTZ);");
-	con->Query("INSERT INTO " + table_name +
+	con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 	           " VALUES (1, 'active', false, NOW()), "
 	           "(2, 'deleted', true, NOW());");
 	con->Commit();
@@ -1373,7 +1386,8 @@ TEST_CASE("Migrate - soft delete to history", "[integration][migrate]") {
 
 	// Verify history columns exist with correct values
 	{
-		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(2, 0) == true);  // id=1 was not deleted, so active
@@ -1382,12 +1396,12 @@ TEST_CASE("Migrate - soft delete to history", "[integration][migrate]") {
 
 	// Verify _fivetran_deleted column is gone
 	{
-		auto res = con->Query("SELECT _fivetran_deleted FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - soft delete to history with custom soft deleted column", "[integration][migrate]") {
@@ -1397,10 +1411,10 @@ TEST_CASE("Migrate - soft delete to history with custom soft deleted column", "[
 	auto con = get_test_connection(MD_TOKEN);
 
 	// Create a table with a custom soft delete column alongside _fivetran_deleted
-	con->Query("CREATE TABLE " + table_name +
+	con->Query("CREATE TABLE " + TEST_SCHEMA_NAME + "." + table_name +
 	           " (id INT PRIMARY KEY, name VARCHAR, is_removed BOOLEAN, "
 	           "_fivetran_deleted BOOLEAN, _fivetran_synced TIMESTAMPTZ);");
-	con->Query("INSERT INTO " + table_name +
+	con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 	           " VALUES (1, 'active', false, false, NOW()), "
 	           "(2, 'removed', true, false, NOW()), "
 	           "(3, 'also_active', false, false, NOW());");
@@ -1421,7 +1435,8 @@ TEST_CASE("Migrate - soft delete to history with custom soft deleted column", "[
 
 	// Verify _fivetran_active is based on is_removed (active = NOT is_removed)
 	{
-		auto res = con->Query("SELECT id, name, _fivetran_active, is_removed FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, name, _fivetran_active, is_removed FROM " + TEST_SCHEMA_NAME + "." +
+		                      table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		// _fivetran_deleted is false everywhere, so the right values are set here.
@@ -1432,19 +1447,19 @@ TEST_CASE("Migrate - soft delete to history with custom soft deleted column", "[
 
 	// Verify _fivetran_deleted column is gone (always dropped)
 	{
-		auto res = con->Query("SELECT _fivetran_deleted FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE(res->HasError());
 	}
 
 	// Verify history columns exist
 	{
-		auto res = con->Query("SELECT _fivetran_start, _fivetran_end FROM " + table_name);
+		auto res = con->Query("SELECT _fivetran_start, _fivetran_end FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}
 
 	// Clean up
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - fails with empty table name", "[integration][migrate]") {
@@ -1483,7 +1498,7 @@ TEST_CASE("Migrate - unsupported operation returns unsupported", "[integration][
 
 	// Clean up
 	auto con = get_test_connection(MD_TOKEN);
-	con->Query("DROP TABLE IF EXISTS " + table_name);
+	con->Query("DROP TABLE IF EXISTS " + TEST_SCHEMA_NAME + "." + table_name);
 }
 
 TEST_CASE("Migrate - works with schema", "[integration][migrate]") {

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -139,7 +139,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check inserted rows
-		auto res = con->Query("SELECT id, title, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		check_row(res, 0, {1, "The Hitchhiker's Guide to the Galaxy", 42});
@@ -164,7 +164,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check after upsert
-		auto res = con->Query("SELECT id, title, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 
 		REQUIRE(res->RowCount() == 4);
@@ -192,7 +192,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check after delete
-		auto res = con->Query("SELECT id, title, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		// row 1 got deleted
@@ -220,7 +220,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check after update
-		auto res = con->Query("SELECT id, title, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		check_row(res, 0, {2, "The empire strikes back", 1});
@@ -245,7 +245,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check truncated table
-		auto res = con->Query("SELECT title, id, magic_number FROM " + table_name +
+		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " WHERE _fivetran_deleted = false ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		// the 1st row from books_update.csv that had 2024-02-08T23:59:59.999999999Z
@@ -256,7 +256,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check the rows did not get physically deleted
-		auto res = con->Query("SELECT title, id, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}
@@ -275,7 +275,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check truncated table is the same as before
-		auto res = con->Query("SELECT title FROM " + table_name + " WHERE _fivetran_deleted = false ORDER BY id");
+		auto res = con->Query("SELECT title FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE _fivetran_deleted = false ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0) == "The empire strikes back");
@@ -283,7 +283,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check again that the rows did not get physically deleted
-		auto res = con->Query("SELECT title, id, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}
@@ -304,7 +304,7 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check the rows got physically deleted
-		auto res = con->Query("SELECT title, id, magic_number FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 0);
 	}
@@ -326,7 +326,7 @@ TEST_CASE("WriteBatch with blob and unmodified string", "[integration][write-bat
 
 	auto con = get_test_connection(MD_TOKEN);
 	{
-		auto res = con->Query("INSERT INTO " + table_name + " VALUES (1, 'Test title', null, false, NOW())");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'Test title', null, false, NOW())");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -349,7 +349,7 @@ TEST_CASE("WriteBatch with blob and unmodified string", "[integration][write-bat
 
 	{
 		// check inserted rows
-		auto res = con->Query("SELECT id, title, blob FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, title, blob FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		check_row(res, 0, {1, "Test title", "test binary"});
@@ -403,7 +403,7 @@ TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 
 	{
 		// check inserted rows
-		auto res = con->Query("SELECT id1, id2, text FROM " + table_name + " ORDER BY id1, id2");
+		auto res = con->Query("SELECT id1, id2, text FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		check_row(res, 0, {1, 100, "first row"});
@@ -430,7 +430,7 @@ TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 
 	{
 		// check after update, including a soft delete
-		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + table_name + " ORDER BY id1, id2");
+		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		check_row(res, 0, {1, 100, "first row", false});
@@ -455,7 +455,7 @@ TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 
 	{
 		// check after hard delete
-		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + table_name + " ORDER BY id1, id2");
+		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		check_row(res, 0, {2, 200, "second row updated", false});
@@ -722,9 +722,9 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
 	{
 		// Insert some test data to validate after primary key modification
-		auto res = con->Query("INSERT INTO " + table_name + "(id, name, id_new) VALUES (1, 'one', 101)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name, id_new) VALUES (1, 'one', 101)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("INSERT INTO " + table_name + "(id, name, id_new) VALUES (2, 'two', 102)");
+		auto res2 = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name, id_new) VALUES (2, 'two', 102)");
 		REQUIRE_NO_FAIL(res2);
 	}
 
@@ -756,7 +756,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
 	{
 		// Make sure the data is still correct after recreating the table
-		auto res = con->Query("SELECT id, name, id_new FROM " + table_name);
+		auto res = con->Query("SELECT id, name, id_new FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == "1");
@@ -794,7 +794,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
 	{
 		// Make sure the data is still correct after recreating the table
-		auto res = con->Query("SELECT id, name FROM " + table_name);
+		auto res = con->Query("SELECT id, name FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == "1");
@@ -824,7 +824,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 	{
 
 		// Make sure the defaults are set correctly
-		auto res = con->Query("SELECT * FROM " + table_name);
+		auto res = con->Query("SELECT * FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == "1");
@@ -871,7 +871,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
 	{
 		// Make sure the defaults are set correctly
-		auto res = con->Query("SELECT * FROM " + table_name);
+		auto res = con->Query("SELECT * FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == "1");
@@ -963,7 +963,7 @@ TEST_CASE("WriteHistoryBatch with update files", "[integration][write-batch]") {
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " +
+		                      " FROM " + TEST_SCHEMA_NAME + "." +
 		                      table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 
@@ -1008,7 +1008,7 @@ TEST_CASE("WriteHistoryBatch with update files", "[integration][write-batch]") {
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " +
+		                      " FROM " + TEST_SCHEMA_NAME + "." +
 		                      table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 5);
@@ -1092,7 +1092,7 @@ TEST_CASE("WriteHistoryBatch upsert and delete", "[integration][write-batch]") {
 	{
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " +
+		                      " FROM " + TEST_SCHEMA_NAME + "." +
 		                      table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
@@ -1162,7 +1162,7 @@ TEST_CASE("WriteHistoryBatch upsert and delete", "[integration][write-batch]") {
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " +
+		                      " FROM " + TEST_SCHEMA_NAME + "." +
 		                      table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
@@ -1217,7 +1217,7 @@ TEST_CASE("WriteHistoryBatch should delete overlapping records", "[integration][
 	{
 		auto con = get_test_connection(MD_TOKEN);
 
-		auto res = con->Query("SELECT title, _fivetran_start FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT title, _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		REQUIRE(res->GetValue(0, 1) == "The Two Towers Updated Title");
@@ -1257,7 +1257,7 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with reordered CSV columns", "[integ
 	{
 		// Verify initial data was inserted correctly despite column order mismatch
 		auto res = con->Query("SELECT id, title, magic_number, blob, _fivetran_active"
-		                      " FROM " +
+		                      " FROM " + TEST_SCHEMA_NAME + "." +
 		                      table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
@@ -1289,7 +1289,7 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with reordered CSV columns", "[integ
 	{
 		// Verify the update was applied correctly - id=1 should have new values,
 		// id=2 should have preserved values from the unmodified marker
-		auto res = con->Query("SELECT id, title, magic_number, blob FROM " + table_name +
+		auto res = con->Query("SELECT id, title, magic_number, blob FROM " + TEST_SCHEMA_NAME + "." + table_name +
 		                      " WHERE _fivetran_start >= '2025-03-01' ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
@@ -1364,7 +1364,7 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with upsert", "[integration][write-b
 
 	auto con = get_test_connection(MD_TOKEN);
 	{
-		auto res = con->Query("SELECT id, amount, \"desc\", _fivetran_synced, FROM " + transaction_table_name +
+		auto res = con->Query("SELECT id, amount, \"desc\", _fivetran_synced, FROM " + TEST_SCHEMA_NAME + "." + transaction_table_name +
 		                      " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 6);
@@ -1392,7 +1392,7 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with upsert", "[integration][write-b
 		// check that id=2 ("The Two Towers") got deleted because it's newer than
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, amount, _fivetran_active"
-		                      " FROM " +
+		                      " FROM " + TEST_SCHEMA_NAME + "." +
 		                      transaction_history_table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 7);
@@ -1615,7 +1615,7 @@ TEST_CASE("AlterTable decimal width change", "[integration]") {
 	};
 
 	auto verify_data = [&](const std::string& expected_amount) {
-		auto res = con->Query("SELECT id, amount FROM " + table_name);
+		auto res = con->Query("SELECT id, amount FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0).ToString() == "1");
@@ -1630,7 +1630,7 @@ TEST_CASE("AlterTable decimal width change", "[integration]") {
 	             });
 	{
 		// Insert test data
-		auto res = con->Query("INSERT INTO " + table_name + " (id, amount) VALUES (1, 1234567890123.4567)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " (id, amount) VALUES (1, 1234567890123.4567)");
 		REQUIRE_NO_FAIL(res);
 	}
 

--- a/test/integration/test_server_parallel.cpp
+++ b/test/integration/test_server_parallel.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Parallel WriteBatch requests", "[integration][write-batch][parallel]"
 
 	auto con = get_test_connection(MD_TOKEN);
 	for (const auto& table_name : table_names) {
-		auto res = con->Query("SELECT id, title FROM " + table_name + " ORDER BY id");
+		auto res = con->Query("SELECT id, title FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -35,6 +35,13 @@ int main(const int argc, char* argv[]) {
 			          << std::endl;
 			exit(5);
 		}
+		const auto create_schema_res =
+		    con.Query("CREATE SCHEMA \"" + db_name + "\".\"" + test::constants::TEST_SCHEMA_NAME + "\"");
+		if (create_schema_res->HasError()) {
+			std::cerr << "Could not create schema " << test::constants::TEST_SCHEMA_NAME
+			          << " at test start: " << create_schema_res->GetError() << std::endl;
+			exit(5);
+		}
 	}
 
 	const int result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
Pass fully qualified table names where we did not pass them before. This was giving errors for the migrate endpoint where tables `x` was not found, but duckdb was suggesting `did you mean y.x?` where `y` was the schema, suggesting this was a search path issue. We now pass the "absolute" name.

To avoid this in the future, I changed the signature of several helper functions to accept a table_def instead of a string and made a lot of integration tests explicitly use a new test schema that is not main.