### PR TITLE
Do not log DEBUG logs to stdout

### DIFF
--- a/src/md_logging.cpp
+++ b/src/md_logging.cpp
@@ -51,7 +51,9 @@ Logger::Logger(duckdb::Connection* con_) : enabled_sinks(SinkType::STDOUT | Sink
 }
 
 void Logger::log_to_stdout(const LogLevel level, const std::string& message) const {
-	std::cout << "{\"level\":\"" << level_to_string(level) << "\",\"message\":\""
+	// Fivetran does not support DEBUG level on stdout, emit as INFO instead.
+	const LogLevel stdout_level = level == LogLevel::DEBUG ? LogLevel::INFO : level;
+	std::cout << "{\"level\":\"" << level_to_string(stdout_level) << "\",\"message\":\""
 	          << duckdb::KeywordHelper::EscapeQuotes(message, '"') << ", duckdb_id=<" << duckdb_id
 	          << ">, connection_id=<" << connection_id << ">\",\"message-origin\":\"sdk_destination\"}" << std::endl;
 }

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -291,7 +291,8 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 	// Check decimal precision
 
 	{
-		auto res = con->Query("SELECT \"default\", key, column_type FROM (describe " + TEST_SCHEMA_NAME + "." + to_table + ")");
+		auto res = con->Query("SELECT \"default\", key, column_type FROM (describe " + TEST_SCHEMA_NAME + "." +
+		                      to_table + ")");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 4); // The order is: id, data, value, amount
 
@@ -447,7 +448,8 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 
 	// Verify destination table has history columns
 	{
-		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + dest_table + " ORDER BY id");
+		auto res = con->Query("SELECT id, name, _fivetran_active FROM " + TEST_SCHEMA_NAME + "." + dest_table +
+		                      " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		// Alice (not deleted) -> active
@@ -465,8 +467,8 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 	} else {
 		// We want check here that soft_deleted_column is not a PK, so we can ignore
 		// this column when we verify the whole PK below
-		auto res = con->Query("SELECT key FROM (describe " + TEST_SCHEMA_NAME + "." + dest_table + ") WHERE column_name = \'" +
-		                      soft_deleted_column + "\'");
+		auto res = con->Query("SELECT key FROM (describe " + TEST_SCHEMA_NAME + "." + dest_table +
+		                      ") WHERE column_name = \'" + soft_deleted_column + "\'");
 		REQUIRE_NO_FAIL(res);
 
 		// soft_deleted_column is not a pk
@@ -482,8 +484,8 @@ TEST_CASE("Migrate - copy table to history mode from soft delete", "[integration
 
 	// Verify id is part of primary key and defaults are set
 	{
-		auto res = con->Query("SELECT key, \"default\" FROM (describe " + TEST_SCHEMA_NAME + "." + dest_table + ") WHERE column_name != \'" +
-		                      soft_deleted_column + "\' ORDER BY column_name");
+		auto res = con->Query("SELECT key, \"default\" FROM (describe " + TEST_SCHEMA_NAME + "." + dest_table +
+		                      ") WHERE column_name != \'" + soft_deleted_column + "\' ORDER BY column_name");
 		REQUIRE_NO_FAIL(res);
 		// The order is: _fivetran_active, _fivetran_end, _fivetran_start, _fivetran_synced, id, name
 		REQUIRE(res->RowCount() == 6);

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -139,7 +139,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check inserted rows
-		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		check_row(res, 0, {1, "The Hitchhiker's Guide to the Galaxy", 42});
@@ -164,7 +165,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check after upsert
-		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 
 		REQUIRE(res->RowCount() == 4);
@@ -192,7 +194,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check after delete
-		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		// row 1 got deleted
@@ -220,7 +223,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check after update
-		auto res = con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		check_row(res, 0, {2, "The empire strikes back", 1});
@@ -256,7 +260,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check the rows did not get physically deleted
-		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}
@@ -275,7 +280,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check truncated table is the same as before
-		auto res = con->Query("SELECT title FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE _fivetran_deleted = false ORDER BY id");
+		auto res = con->Query("SELECT title FROM " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " WHERE _fivetran_deleted = false ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0) == "The empire strikes back");
@@ -283,7 +289,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check again that the rows did not get physically deleted
-		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 	}
@@ -304,7 +311,8 @@ TEST_CASE("WriteBatch", "[integration][write-batch]") {
 
 	{
 		// check the rows got physically deleted
-		auto res = con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT title, id, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 0);
 	}
@@ -326,7 +334,8 @@ TEST_CASE("WriteBatch with blob and unmodified string", "[integration][write-bat
 
 	auto con = get_test_connection(MD_TOKEN);
 	{
-		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " VALUES (1, 'Test title', null, false, NOW())");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " VALUES (1, 'Test title', null, false, NOW())");
 		REQUIRE_NO_FAIL(res);
 	}
 
@@ -403,7 +412,8 @@ TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 
 	{
 		// check inserted rows
-		auto res = con->Query("SELECT id1, id2, text FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
+		auto res =
+		    con->Query("SELECT id1, id2, text FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		check_row(res, 0, {1, 100, "first row"});
@@ -430,7 +440,8 @@ TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 
 	{
 		// check after update, including a soft delete
-		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
+		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " ORDER BY id1, id2");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		check_row(res, 0, {1, 100, "first row", false});
@@ -455,7 +466,8 @@ TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
 
 	{
 		// check after hard delete
-		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id1, id2");
+		auto res = con->Query("SELECT id1, id2, text, _fivetran_deleted FROM " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " ORDER BY id1, id2");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 		check_row(res, 0, {2, 200, "second row updated", false});
@@ -722,9 +734,11 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
 	{
 		// Insert some test data to validate after primary key modification
-		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name, id_new) VALUES (1, 'one', 101)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      "(id, name, id_new) VALUES (1, 'one', 101)");
 		REQUIRE_NO_FAIL(res);
-		auto res2 = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name, id_new) VALUES (2, 'two', 102)");
+		auto res2 = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                       "(id, name, id_new) VALUES (2, 'two', 102)");
 		REQUIRE_NO_FAIL(res2);
 	}
 
@@ -963,8 +977,8 @@ TEST_CASE("WriteHistoryBatch with update files", "[integration][write-batch]") {
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " + TEST_SCHEMA_NAME + "." +
-		                      table_name + " ORDER BY id, _fivetran_start");
+		                      " FROM " +
+		                      TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 
 		REQUIRE(res->RowCount() == 3);
@@ -1008,8 +1022,8 @@ TEST_CASE("WriteHistoryBatch with update files", "[integration][write-batch]") {
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " + TEST_SCHEMA_NAME + "." +
-		                      table_name + " ORDER BY id, _fivetran_start");
+		                      " FROM " +
+		                      TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 5);
 
@@ -1092,8 +1106,8 @@ TEST_CASE("WriteHistoryBatch upsert and delete", "[integration][write-batch]") {
 	{
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " + TEST_SCHEMA_NAME + "." +
-		                      table_name + " ORDER BY id, _fivetran_start");
+		                      " FROM " +
+		                      TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 
@@ -1162,8 +1176,8 @@ TEST_CASE("WriteHistoryBatch upsert and delete", "[integration][write-batch]") {
 		// the date in books_history_earliest.csv
 		auto res = con->Query("SELECT id, title, magic_number, _fivetran_synced, "
 		                      "_fivetran_active, _fivetran_start, _fivetran_end"
-		                      " FROM " + TEST_SCHEMA_NAME + "." +
-		                      table_name + " ORDER BY id, _fivetran_start");
+		                      " FROM " +
+		                      TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 1);
 
@@ -1217,7 +1231,8 @@ TEST_CASE("WriteHistoryBatch should delete overlapping records", "[integration][
 	{
 		auto con = get_test_connection(MD_TOKEN);
 
-		auto res = con->Query("SELECT title, _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		auto res =
+		    con->Query("SELECT title, _fivetran_start FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 3);
 		REQUIRE(res->GetValue(0, 1) == "The Two Towers Updated Title");
@@ -1257,8 +1272,8 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with reordered CSV columns", "[integ
 	{
 		// Verify initial data was inserted correctly despite column order mismatch
 		auto res = con->Query("SELECT id, title, magic_number, blob, _fivetran_active"
-		                      " FROM " + TEST_SCHEMA_NAME + "." +
-		                      table_name + " ORDER BY id");
+		                      " FROM " +
+		                      TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 
@@ -1364,8 +1379,8 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with upsert", "[integration][write-b
 
 	auto con = get_test_connection(MD_TOKEN);
 	{
-		auto res = con->Query("SELECT id, amount, \"desc\", _fivetran_synced, FROM " + TEST_SCHEMA_NAME + "." + transaction_table_name +
-		                      " ORDER BY id");
+		auto res = con->Query("SELECT id, amount, \"desc\", _fivetran_synced, FROM " + TEST_SCHEMA_NAME + "." +
+		                      transaction_table_name + " ORDER BY id");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 6);
 
@@ -1391,9 +1406,10 @@ TEST_CASE("WriteBatch and WriteHistoryBatch with upsert", "[integration][write-b
 	{
 		// check that id=2 ("The Two Towers") got deleted because it's newer than
 		// the date in books_history_earliest.csv
-		auto res = con->Query("SELECT id, amount, _fivetran_active"
-		                      " FROM " + TEST_SCHEMA_NAME + "." +
-		                      transaction_history_table_name + " ORDER BY id, _fivetran_start");
+		auto res =
+		    con->Query("SELECT id, amount, _fivetran_active"
+		               " FROM " +
+		               TEST_SCHEMA_NAME + "." + transaction_history_table_name + " ORDER BY id, _fivetran_start");
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 7);
 
@@ -1630,7 +1646,8 @@ TEST_CASE("AlterTable decimal width change", "[integration]") {
 	             });
 	{
 		// Insert test data
-		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + " (id, amount) VALUES (1, 1234567890123.4567)");
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      " (id, amount) VALUES (1, 1234567890123.4567)");
 		REQUIRE_NO_FAIL(res);
 	}
 


### PR DESCRIPTION
Log info to stdout for info logs because Fivetran does not support debug logs. Also applies some missing formatting changes.