### PR TITLE
Return a task to the user when primary key constraints are violated on an AlterTable request

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -249,7 +249,10 @@ private:
 	void run_query(duckdb::Connection& con, const std::string& log_prefix, const std::string& query,
 	               const std::string& error_message) const;
 	void alter_table_recreate(duckdb::Connection& con, const table_def& table,
-	                          const std::vector<column_def>& all_columns, const std::set<std::string>& common_columns);
+	                          const std::vector<column_def>& all_columns_in_new_table, const std::set<std::string>& common_columns);
+	void check_no_duplicate_primary_keys(duckdb::Connection& con, const table_def& table,
+	                                     const std::vector<column_def>& all_columns,
+	                                     const std::set<std::string>& common_columns) const;
 	void alter_table_in_place(duckdb::Connection& con, const table_def& table,
 	                          const std::vector<column_def>& added_columns,
 	                          const std::set<std::string>& deleted_columns, const std::set<std::string>& alter_types,

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -251,8 +251,8 @@ private:
 	void alter_table_recreate(duckdb::Connection& con, const table_def& table,
 	                          const std::vector<column_def>& all_columns_in_new_table, const std::set<std::string>& common_columns);
 	void check_no_duplicate_primary_keys(duckdb::Connection& con, const table_def& table,
-	                                     const std::vector<column_def>& all_columns,
-	                                     const std::set<std::string>& common_columns) const;
+	                                     const std::vector<column_def>& all_columns_in_new_table,
+	                                     const std::set<std::string>& existing_columns_in_new_table) const;
 	void alter_table_in_place(duckdb::Connection& con, const table_def& table,
 	                          const std::vector<column_def>& added_columns,
 	                          const std::set<std::string>& deleted_columns, const std::set<std::string>& alter_types,

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -374,9 +374,72 @@ void MdSqlGenerator::drop_column(duckdb::Connection& con, const table_def& table
 	                 "Could not drop column <" + column_name + "> of table <" + table.to_escaped_string() + ">");
 }
 
+void MdSqlGenerator::check_no_duplicate_primary_keys(duckdb::Connection& con, const table_def& table,
+                                                     const std::vector<column_def>& all_new_columns,
+                                                     const std::set<std::string>& existing_columns_in_new_table) const {
+	// When the primary key changes, we only need to check that the existing columns that are part of it are unique.
+	std::vector<std::string> new_pk_cols;
+	std::vector<std::string> existing_pk_columns_in_new_table;
+	for (const auto& col : all_new_columns) {
+		if (col.primary_key) {
+			new_pk_cols.push_back(col.name);
+			if (existing_columns_in_new_table.find(col.name) != existing_columns_in_new_table.end()) {
+				existing_pk_columns_in_new_table.push_back(col.name);
+			}
+		}
+	}
+
+	// No primary key on the new table means no uniqueness constraint to violate.
+	if (new_pk_cols.empty()) {
+		return;
+	}
+
+	const auto absolute_table_name = table.to_escaped_string();
+	bool has_duplicates;
+
+	if (!existing_pk_columns_in_new_table.empty()) {
+		std::ostringstream sql;
+		sql << "SELECT 1 FROM " << absolute_table_name << " GROUP BY ";
+		join(sql, existing_pk_columns_in_new_table,
+		     [](std::ostream& out, const std::string& col) { out << KeywordHelper::WriteQuoted(col, '"'); });
+		sql << " HAVING COUNT(*) > 1 LIMIT 1";
+
+		const auto query = sql.str();
+		logger.info("check_no_duplicate_primary_keys: " + query);
+		const auto result = con.Query(query);
+		if (result->HasError()) {
+			throw std::runtime_error("Could not check for duplicate primary keys in table <" + absolute_table_name +
+			                         ">: " + result->GetError());
+		}
+		has_duplicates = result->RowCount() > 0;
+	} else {
+		// All new primary key columns are newly added, so every existing row would
+		// share the same (constant default) key. Any more than one row is a duplicate.
+		const std::string query = "SELECT COUNT(*) FROM " + absolute_table_name;
+		logger.info("check_no_duplicate_primary_keys: " + query);
+		const auto result = con.Query(query);
+		if (result->HasError()) {
+			throw std::runtime_error("Could not check for duplicate primary keys in table <" + absolute_table_name +
+			                         ">: " + result->GetError());
+		}
+		has_duplicates = result->GetValue(0, 0).GetValue<int64_t>() > 1;
+	}
+
+	if (has_duplicates) {
+		throw md_error::RecoverableError(
+		    "The requested primary key change on " + table.schema_name + "." + table.table_name +
+		    " would create duplicate rows. To proceed, either manually remove the duplicate records or drop the table "
+		    "and trigger a historical re-sync.");
+	}
+}
+
 void MdSqlGenerator::alter_table_recreate(duckdb::Connection& con, const table_def& table,
-                                          const std::vector<column_def>& all_columns,
-                                          const std::set<std::string>& common_columns) {
+                                          const std::vector<column_def>& all_new_columns,
+                                          const std::set<std::string>& existing_columns_in_new_table) {
+	// Bail out before any DDL if the new primary key would not be unique over the
+	// existing data; the surrounding transaction rolls back cleanly on throw.
+	check_no_duplicate_primary_keys(con, table, all_new_columns, existing_columns_in_new_table);
+
 	long timestamp =
 	    std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 	auto temp_table =
@@ -388,18 +451,18 @@ void MdSqlGenerator::alter_table_recreate(duckdb::Connection& con, const table_d
 
 	// new primary keys have to get a default value as they cannot be null
 	std::set<std::string> new_primary_key_cols;
-	for (const auto& col : all_columns) {
-		if (col.primary_key && common_columns.find(col.name) == common_columns.end()) {
+	for (const auto& col : all_new_columns) {
+		if (col.primary_key && existing_columns_in_new_table.find(col.name) == existing_columns_in_new_table.end()) {
 			new_primary_key_cols.insert(col.name);
 		}
 	}
 
-	create_table(con, table, all_columns, new_primary_key_cols);
+	create_table(con, table, all_new_columns, new_primary_key_cols);
 
 	// reinsert the data from the old table
 	std::ostringstream out_column_list;
 	bool first = true;
-	for (auto& col : common_columns) {
+	for (auto& col : existing_columns_in_new_table) {
 		if (first) {
 			first = false;
 		} else {

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -434,11 +434,11 @@ void MdSqlGenerator::check_no_duplicate_primary_keys(duckdb::Connection& con, co
 }
 
 void MdSqlGenerator::alter_table_recreate(duckdb::Connection& con, const table_def& table,
-                                          const std::vector<column_def>& all_new_columns,
+                                          const std::vector<column_def>& all_columns_in_new_table,
                                           const std::set<std::string>& existing_columns_in_new_table) {
 	// Bail out before any DDL if the new primary key would not be unique over the
 	// existing data; the surrounding transaction rolls back cleanly on throw.
-	check_no_duplicate_primary_keys(con, table, all_new_columns, existing_columns_in_new_table);
+	check_no_duplicate_primary_keys(con, table, all_columns_in_new_table, existing_columns_in_new_table);
 
 	long timestamp =
 	    std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
@@ -451,13 +451,13 @@ void MdSqlGenerator::alter_table_recreate(duckdb::Connection& con, const table_d
 
 	// new primary keys have to get a default value as they cannot be null
 	std::set<std::string> new_primary_key_cols;
-	for (const auto& col : all_new_columns) {
+	for (const auto& col : all_columns_in_new_table) {
 		if (col.primary_key && existing_columns_in_new_table.find(col.name) == existing_columns_in_new_table.end()) {
 			new_primary_key_cols.insert(col.name);
 		}
 	}
 
-	create_table(con, table, all_new_columns, new_primary_key_cols);
+	create_table(con, table, all_columns_in_new_table, new_primary_key_cols);
 
 	// reinsert the data from the old table
 	std::ostringstream out_column_list;

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -1571,6 +1571,106 @@ TEST_CASE("AlterTable must not drop columns unless specified", "[integration]") 
 	}
 }
 
+TEST_CASE("AlterTable raises a task if a primary key change would create duplicates", "[integration]") {
+	DestinationSdkImpl service;
+
+	const std::string table_name = "some_table" + std::to_string(randint());
+
+	auto con = get_test_connection(MD_TOKEN);
+	create_table(service, table_name,
+	             std::array {
+	                 column_def {.name = "id", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "name", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	             });
+
+	{
+		// Two rows that share an "id" but differ on "name". The composite PK
+		// (id, name) is unique, but "id" alone is not.
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      "(id, name) VALUES ('1', 'a'), ('1', 'b')");
+		REQUIRE_NO_FAIL(res);
+	}
+
+	{
+		// Change the PK to (id, name2), where name2 is a new column, while "id" is not unique
+		::fivetran_sdk::v2::AlterTableRequest request;
+
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
+		add_col(request, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+		add_col(request, "name", ::fivetran_sdk::v2::DataType::STRING, false);
+		add_col(request, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
+
+		::fivetran_sdk::v2::AlterTableResponse response;
+		auto status = service.AlterTable(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+		REQUIRE(response.has_task());
+		REQUIRE_THAT(response.task().message(), Catch::Matchers::ContainsSubstring("would create duplicate rows"));
+	}
+
+	{
+		// The table must be untouched
+		auto response = describe_table(service, table_name);
+		REQUIRE(!response.not_found());
+		REQUIRE(response.table().columns_size() == 2);
+		check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+		check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, true);
+
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
+		REQUIRE_NO_FAIL(res);
+		REQUIRE(res->GetValue(0, 0).GetValue<int64_t>() == 2);
+	}
+}
+
+TEST_CASE("AlterTable changes the primary key when the new key stays unique", "[integration]") {
+	DestinationSdkImpl service;
+
+	const std::string table_name = "some_table" + std::to_string(randint());
+
+	auto con = get_test_connection(MD_TOKEN);
+	create_table(service, table_name,
+	             std::array {
+	                 column_def {.name = "id", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "name", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	             });
+
+	{
+		// Distinct "id" values, so dropping "name" from the PK is still unique.
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      "(id, name) VALUES ('1', 'a'), ('2', 'b')");
+		REQUIRE_NO_FAIL(res);
+	}
+
+	{
+		// Same PK change as the duplicate test, but the existing data keeps the new
+		// key unique, so the recreate should succeed.
+		::fivetran_sdk::v2::AlterTableRequest request;
+
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
+		add_col(request, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+		add_col(request, "name", ::fivetran_sdk::v2::DataType::STRING, false);
+		add_col(request, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
+
+		::fivetran_sdk::v2::AlterTableResponse response;
+		auto status = service.AlterTable(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+		REQUIRE(!response.has_task());
+	}
+
+	{
+		auto response = describe_table(service, table_name);
+		REQUIRE(!response.not_found());
+		REQUIRE(response.table().columns_size() == 3);
+		check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+		check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, false);
+		check_column(response, 2, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
+
+		// The original data is preserved through the recreate.
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
+		REQUIRE_NO_FAIL(res);
+		REQUIRE(res->GetValue(0, 0).GetValue<int64_t>() == 2);
+	}
+}
+
 TEST_CASE("AlterTable must drop columns when specified", "[integration]") {
 	DestinationSdkImpl service;
 


### PR DESCRIPTION
As discussed, when sources try to set an invalid primary key on the destination, we should fail and tell the user how to resolve this.