### PR TITLE
Update DuckDB and libfmt dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(FETCHCONTENT_QUIET OFF)
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt
-        GIT_TAG        407c905e45ad75fc29bf0f9bb7c5c2fd3475976f # 12.1.0
+        GIT_TAG        1be298e1bd68957e4cd352e1f676f00e07dcfb57 # 12.2.0
         GIT_SHALLOW TRUE
         SYSTEM
 )
@@ -65,7 +65,7 @@ FetchContent_MakeAvailable(fmt)
 FetchContent_Declare(
     duckdb
     GIT_REPOSITORY https://github.com/duckdb/duckdb.git
-    GIT_TAG 6ddac802ffa9bcfbcc3f5f0d71de5dff9b0bc250 # v1.4.4
+    GIT_TAG 08e34c447bae34eaee3723cac61f2878b6bdf787 # v1.5.4
     GIT_SHALLOW TRUE
     SYSTEM
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ target_include_directories(motherduck_destination_sources SYSTEM PUBLIC
 
 target_link_libraries(motherduck_destination_sources PUBLIC
         duckdb_static
+        duckdb_generated_extension_loader
+        parquet_extension
+        core_functions_extension
         fivetran_sdk
         OpenSSL::Crypto
         fmt::fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,13 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_BACKUP})
 
 set(DuckDB_INCLUDE_DIRS ${DuckDB_SOURCE_DIR}/src/include)
 
+# duckdb_static references duckdb::ExtensionHelper::LoadAllExtensions
+# which is defined in duckdb_generated_extension_loader.
+set_property(TARGET duckdb_static APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES duckdb_generated_extension_loader)
+set_property(TARGET duckdb_generated_extension_loader APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES core_functions_extension parquet_extension)
+
 ### Store latest git commit SHA ###
 if(DEFINED GIT_COMMIT_SHA_OVERRIDE AND NOT GIT_COMMIT_SHA_OVERRIDE STREQUAL "")
     set(GIT_COMMIT_SHA ${GIT_COMMIT_SHA_OVERRIDE})
@@ -169,9 +176,6 @@ target_include_directories(motherduck_destination_sources SYSTEM PUBLIC
 
 target_link_libraries(motherduck_destination_sources PUBLIC
         duckdb_static
-        duckdb_generated_extension_loader
-        parquet_extension
-        core_functions_extension
         fivetran_sdk
         OpenSSL::Crypto
         fmt::fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ FetchContent_MakeAvailable(duckdb)
 # Restore build type
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_BACKUP})
 
-get_target_property(DuckDB_INCLUDE_DIRS duckdb_static INTERFACE_INCLUDE_DIRECTORIES)
+set(DuckDB_INCLUDE_DIRS ${DuckDB_SOURCE_DIR}/src/include)
 
 ### Store latest git commit SHA ###
 if(DEFINED GIT_COMMIT_SHA_OVERRIDE AND NOT GIT_COMMIT_SHA_OVERRIDE STREQUAL "")

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -299,7 +299,7 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		// duckdb::Value() creates a NULL value
 		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                                 // id
 		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});                       // data
-		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17,4))", duckdb::Value(), "DECIMAL(17,4)"}); // value
+		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17, 4))", duckdb::Value(), "DECIMAL(17,4)"}); // value
 		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"});                 // amount
 	}
 


### PR DESCRIPTION
Bumps DuckDB from v1.4.4 to v1.5.4 and libfmt from v12.1.0 to v12.2.0.

Since https://github.com/duckdb/duckdb/pull/19369 (late extension linking), core_functions and parquet are separate archives and have to be linked explicitly. Furthermore, DuckDB doesn't set the `INCLUDE_DIRS` property anymore on its CMake targets. Therefore, the DuckDB include dir (the place where duckdb.hpp is located) is now hardcoded to duckdb/src/include.

Also in DuckDB v1.5, the string representation for the `DECIMAL` type now has an extra space (see the column name in this output):
```
~ duckman run v1.4.4
D SELECT CAST(42 AS DECIMAL(17,4));
┌───────────────────────────┐
│ CAST(42 AS DECIMAL(17,4)) │
│       decimal(17,4)       │
├───────────────────────────┤
│          42.0000          │
└───────────────────────────┘
D

~ duckman run v1.5.4
D SELECT CAST(42 AS DECIMAL(17,4));
┌────────────────────────────┐
│ CAST(42 AS DECIMAL(17, 4)) │
│       decimal(17,4)        │
├────────────────────────────┤
│                    42.0000 │
└────────────────────────────┘
```