### PR TITLE
Add name to cache step in build workflow

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,12 +16,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
+        name: Cache dependencies
         id: cache-deps
         with:
           key: fivetran-deps-${{ hashFiles('./Makefile') }}
           path: ./install
 
-      - name: build the dependencies
+      - name: Build the dependencies
         if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
         env:
           CC: clang-15
@@ -30,7 +31,7 @@ jobs:
         run: |
           make build_openssl_native build_grpc build_test_dependencies
 
-      - name: build the connector
+      - name: Build the connector
         env:
           CC: clang-15
           CXX: clang++-15
@@ -39,7 +40,7 @@ jobs:
           make get_fivetran_protos
           make build_connector_debug
 
-      - name: run tests
+      - name: Run tests
         env:
           motherduck_token: ${{ secrets.CI_TESTING_TOKEN }}
         run: ./build/Debug/integration_tests


### PR DESCRIPTION
Gives the `cache-deps` step a name to make it clearer what gets cached. Currently, the default name "Run actions/cache@v3" is shown.
Also makes the other step names start with an uppercase letter to be consistent with the default GitHub naming scheme.