### PR TITLE
Upgrade actions/checkout and actions/cache versions

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v6
         id: cache-deps
         with:
           key: fivetran-deps-${{ hashFiles('./Makefile') }}


### PR DESCRIPTION
Updates GitHub Actions to newer versions that support Node24. Node20 is deprecated and has reached end-of-life in April 2026. For actions/cache, Node24 support was added in [v5](https://github.com/actions/cache#v5). For actions/checkout, Node24 support was added in [v5](https://github.com/actions/checkout#checkout-v5).