### PR TITLE
Add "Strict Primary Keys" property to configuration form

### DIFF
--- a/includes/config.hpp
+++ b/includes/config.hpp
@@ -31,7 +31,7 @@ std::optional<std::string> find_optional_property(const MapLike& config, const s
 }
 
 /// Reads a boolean-valued property (toggle field). Only the string "true" is interpreted as true.
-/// A missing field or empty value resolved to the provided `default_value` to allow keeping the existing behavior
+/// A missing field or empty value resolves to the provided `default_value` to allow keeping the existing behavior
 /// unchanged.
 template <typename MapLike>
 bool find_bool_property(const MapLike& config, const std::string& property_name, bool default_value) {

--- a/includes/config.hpp
+++ b/includes/config.hpp
@@ -31,7 +31,8 @@ std::optional<std::string> find_optional_property(const MapLike& config, const s
 }
 
 /// Reads a boolean-valued property (toggle field). Only the string "true" is interpreted as true.
-/// A missing field or empty value resolved to the provided `default_value` to allow keeping the existing behavior unchanged.
+/// A missing field or empty value resolved to the provided `default_value` to allow keeping the existing behavior
+/// unchanged.
 template <typename MapLike>
 bool find_bool_property(const MapLike& config, const std::string& property_name, bool default_value) {
 	const auto it = config.find(property_name);

--- a/includes/config.hpp
+++ b/includes/config.hpp
@@ -30,13 +30,13 @@ std::optional<std::string> find_optional_property(const MapLike& config, const s
 	return std::make_optional(it->second);
 }
 
-/// Reads a boolean-valued property (toggle field). Anything other than "true" (including a missing or
-/// empty value) resolves to `false`.
+/// Reads a boolean-valued property (toggle field). Only the string "true" is interpreted as true.
+/// A missing field or empty value resolved to the provided `default_value` to allow keeping the existing behavior unchanged.
 template <typename MapLike>
-bool find_bool_property(const MapLike& config, const std::string& property_name) {
+bool find_bool_property(const MapLike& config, const std::string& property_name, bool default_value) {
 	const auto it = config.find(property_name);
 	if (it == config.end() || it->second.empty()) {
-		return false;
+		return default_value;
 	}
 	return it->second == "true";
 }

--- a/includes/config.hpp
+++ b/includes/config.hpp
@@ -8,22 +8,36 @@ namespace config {
 inline constexpr const char* PROP_DATABASE = "motherduck_database";
 inline constexpr const char* PROP_TOKEN = "motherduck_token";
 inline constexpr const char* PROP_MAX_RECORD_SIZE = "max_record_size";
+inline constexpr const char* PROP_STRICT_PRIMARY_KEYS = "strict_primary_keys";
 
+/// Reads the property with name `property_name` from the config and throws if it is not found.
 template <typename MapLike>
 std::string find_property(const MapLike& config, const std::string& property_name) {
-	const auto token_it = config.find(property_name);
-	if (token_it == config.end()) {
+	const auto it = config.find(property_name);
+	if (it == config.end()) {
 		throw std::invalid_argument("Missing property " + property_name);
 	}
-	return token_it->second;
+	return it->second;
 }
 
+/// Reads the property with name `property_name` from the config or returns std::nullopt if it is not found.
 template <typename MapLike>
 std::optional<std::string> find_optional_property(const MapLike& config, const std::string& property_name) {
-	const auto token_it = config.find(property_name);
-	if (token_it == config.end()) {
+	const auto it = config.find(property_name);
+	if (it == config.end()) {
 		return std::nullopt;
 	}
-	return std::make_optional(token_it->second);
+	return std::make_optional(it->second);
+}
+
+/// Reads a boolean-valued property (toggle field). Anything other than "true" (including a missing or
+/// empty value) resolves to `false`.
+template <typename MapLike>
+bool find_bool_property(const MapLike& config, const std::string& property_name) {
+	const auto it = config.find(property_name);
+	if (it == config.end() || it->second.empty()) {
+		return false;
+	}
+	return it->second == "true";
 }
 } // namespace config

--- a/src/config_tester.cpp
+++ b/src/config_tester.cpp
@@ -26,7 +26,8 @@ TestResult run_authentication_test(duckdb::Connection& con) {
 }
 
 /// Checks that the selected database can be written to
-TestResult run_database_type_test(duckdb::Connection& con, const google::protobuf::Map<std::string, std::string>& configuration) {
+TestResult run_database_type_test(duckdb::Connection& con,
+                                  const google::protobuf::Map<std::string, std::string>& configuration) {
 	const auto current_db_res = con.Query("SELECT current_database()");
 	if (current_db_res->HasError()) {
 		return TestResult(false, "Failed to retrieve current database name: " + current_db_res->GetError());
@@ -72,8 +73,10 @@ TestResult run_database_type_test(duckdb::Connection& con, const google::protobu
 		                             "\" is a read-only MotherDuck share. Please use a "
 		                             "writable database for Fivetran ingestion jobs.");
 	}
-	if (db_type == "motherduck ducklake" && config::find_bool_property(configuration, config::PROP_STRICT_PRIMARY_KEYS, true) == true) {
-		return TestResult(false, "Strict primary keys cannot be enabled when using a Ducklake database. Please turn off the \"Strict Primary Keys\" option.");
+	if (db_type == "motherduck ducklake" &&
+	    config::find_bool_property(configuration, config::PROP_STRICT_PRIMARY_KEYS, true) == true) {
+		return TestResult(false, "Strict primary keys cannot be enabled when using a Ducklake database. Please turn "
+		                         "off the \"Strict Primary Keys\" option.");
 	}
 	if (db_type.find("motherduck") == std::string::npos) {
 		// We expect to run against type "motherduck" or "motherduck <something>"

--- a/src/config_tester.cpp
+++ b/src/config_tester.cpp
@@ -26,7 +26,7 @@ TestResult run_authentication_test(duckdb::Connection& con) {
 }
 
 /// Checks that the selected database can be written to
-TestResult run_database_type_test(duckdb::Connection& con) {
+TestResult run_database_type_test(duckdb::Connection& con, const google::protobuf::Map<std::string, std::string>& configuration) {
 	const auto current_db_res = con.Query("SELECT current_database()");
 	if (current_db_res->HasError()) {
 		return TestResult(false, "Failed to retrieve current database name: " + current_db_res->GetError());
@@ -71,6 +71,9 @@ TestResult run_database_type_test(duckdb::Connection& con) {
 		return TestResult(false, "Catalog \"" + db_name +
 		                             "\" is a read-only MotherDuck share. Please use a "
 		                             "writable database for Fivetran ingestion jobs.");
+	}
+	if (db_type == "motherduck ducklake" && config::find_bool_property(configuration, config::PROP_STRICT_PRIMARY_KEYS) == true) {
+		return TestResult(false, "Strict primary keys cannot be enabled when using a Ducklake database. Please turn off the \"Strict Primary Keys\" option.");
 	}
 	if (db_type.find("motherduck") == std::string::npos) {
 		// We expect to run against type "motherduck" or "motherduck <something>"
@@ -174,7 +177,7 @@ TestResult run_test(const std::string& test_name, duckdb::Connection& con,
 		return run_authentication_test(con);
 	}
 	if (test_name == TEST_DATABASE_TYPE) {
-		return run_database_type_test(con);
+		return run_database_type_test(con, configuration);
 	}
 	if (test_name == TEST_WRITE_PERMISSIONS) {
 		return run_write_permissions_test(con);

--- a/src/config_tester.cpp
+++ b/src/config_tester.cpp
@@ -72,7 +72,7 @@ TestResult run_database_type_test(duckdb::Connection& con, const google::protobu
 		                             "\" is a read-only MotherDuck share. Please use a "
 		                             "writable database for Fivetran ingestion jobs.");
 	}
-	if (db_type == "motherduck ducklake" && config::find_bool_property(configuration, config::PROP_STRICT_PRIMARY_KEYS) == true) {
+	if (db_type == "motherduck ducklake" && config::find_bool_property(configuration, config::PROP_STRICT_PRIMARY_KEYS, true) == true) {
 		return TestResult(false, "Strict primary keys cannot be enabled when using a Ducklake database. Please turn off the \"Strict Primary Keys\" option.");
 	}
 	if (db_type.find("motherduck") == std::string::npos) {

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -183,6 +183,18 @@ grpc::Status DestinationSdkImpl::ConfigurationForm(::grpc::ServerContext*,
 	max_record_size_field.set_required(false);
 	response->add_fields()->CopyFrom(max_record_size_field);
 
+	fivetran_sdk::v2::FormField strict_primary_keys_field;
+	strict_primary_keys_field.set_name(config::PROP_STRICT_PRIMARY_KEYS);
+	strict_primary_keys_field.set_label("Strict Primary Keys");
+	strict_primary_keys_field.set_description(
+		"When enabled, tables are created with an enforced PRIMARY KEY constraint. Consequently, an index has to be built and maintained on the target table. Leave this OFF (the "
+		"default) to mark primary key columns NOT NULL without a uniqueness constraint. This is helpful if uniqueness is already enforced at the source, and required "
+		"for backends that do not support primary keys (such as DuckLake).");
+	strict_primary_keys_field.mutable_toggle_field();
+	strict_primary_keys_field.set_required(false);
+	strict_primary_keys_field.set_default_value("false");
+	response->add_fields()->CopyFrom(strict_primary_keys_field);
+
 	for (const auto& test_case : config_tester::get_test_cases()) {
 		auto connection_test = response->add_tests();
 		connection_test->set_name(test_case.name);

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -187,9 +187,11 @@ grpc::Status DestinationSdkImpl::ConfigurationForm(::grpc::ServerContext*,
 	strict_primary_keys_field.set_name(config::PROP_STRICT_PRIMARY_KEYS);
 	strict_primary_keys_field.set_label("Strict Primary Keys");
 	strict_primary_keys_field.set_description(
-		"When enabled, tables are created with an enforced PRIMARY KEY constraint. Consequently, an index has to be built and maintained on the target table. Leave this OFF (the "
-		"default) to mark primary key columns NOT NULL without a uniqueness constraint. This is helpful if uniqueness is already enforced at the source, and required "
-		"for backends that do not support primary keys (such as DuckLake).");
+	    "When enabled, tables are created with an enforced PRIMARY KEY constraint. Consequently, an index has to be "
+	    "built and maintained on the target table. Leave this OFF (the "
+	    "default) to mark primary key columns NOT NULL without a uniqueness constraint. This is helpful if uniqueness "
+	    "is already enforced at the source, and required "
+	    "for backends that do not support primary keys (such as DuckLake).");
 	strict_primary_keys_field.mutable_toggle_field();
 	strict_primary_keys_field.set_required(false);
 	strict_primary_keys_field.set_default_value("false");

--- a/test/integration/test_config_tester.cpp
+++ b/test/integration/test_config_tester.cpp
@@ -10,6 +10,17 @@
 
 using namespace test::constants;
 
+namespace {
+void ensure_workspace_mode(duckdb::Connection& con) {
+	const auto attach_mode_res = con.Query("SELECT current_setting('motherduck_attach_mode')");
+	REQUIRE_NO_FAIL(attach_mode_res);
+	REQUIRE(attach_mode_res->RowCount() == 1);
+	REQUIRE(attach_mode_res->ColumnCount() == 1);
+	const auto attach_mode = attach_mode_res->GetValue(0, 0).ToString();
+	REQUIRE(attach_mode == "workspace");
+}
+} // namespace
+
 TEST_CASE("Test fails when database missing", "[integration][configtest]") {
 	::fivetran_sdk::v2::TestRequest request;
 	(*request.mutable_configuration())["motherduck_token"] = "12345";
@@ -65,16 +76,9 @@ TEST_CASE("Test endpoint authentication test succeeds when everything is in orde
 
 TEST_CASE("Test fails when motherduck_database is a share", "[integration][configtest]") {
 	auto con = get_test_connection(MD_TOKEN);
+	ensure_workspace_mode(*con);
+
 	const std::string share_name = "fivetran_test_share";
-
-	// Make sure we are in workspace attach mode
-	const auto attach_mode_res = con->Query("SELECT current_setting('motherduck_attach_mode')");
-	REQUIRE_NO_FAIL(attach_mode_res);
-	REQUIRE(attach_mode_res->RowCount() == 1);
-	REQUIRE(attach_mode_res->ColumnCount() == 1);
-	const auto attach_mode = attach_mode_res->GetValue(0, 0).ToString();
-	REQUIRE(attach_mode == "workspace");
-
 	const auto create_res = con->Query("CREATE OR REPLACE SHARE " + share_name + " FROM " + TEST_DATABASE_NAME);
 	REQUIRE_NO_FAIL(create_res);
 	REQUIRE(create_res->RowCount() == 1);
@@ -86,7 +90,7 @@ TEST_CASE("Test fails when motherduck_database is a share", "[integration][confi
 
 	::fivetran_sdk::v2::TestRequest request;
 	request.set_name(config_tester::TEST_DATABASE_TYPE);
-	(*request.mutable_configuration())["motherduck_database"] = "fivetran_test_share";
+	(*request.mutable_configuration())["motherduck_database"] = share_name;
 	(*request.mutable_configuration())["motherduck_token"] = MD_TOKEN;
 
 	DestinationSdkImpl service;
@@ -99,6 +103,32 @@ TEST_CASE("Test fails when motherduck_database is a share", "[integration][confi
 	REQUIRE_NO_FAIL(status);
 	CAPTURE(response.failure());
 	REQUIRE_THAT(response.failure(), Catch::Matchers::ContainsSubstring("is a read-only MotherDuck share"));
+}
+
+TEST_CASE("Test fails when motherduck_database is Ducklake and strict primary keys are enabled", "[integration][configtest]") {
+	auto con = get_test_connection(MD_TOKEN);
+	ensure_workspace_mode(*con);
+
+	const std::string db_name = "fivetran_test_ducklake";
+	const auto create_res = con->Query("CREATE OR REPLACE DATABASE " + db_name + " (TYPE DUCKLAKE)");
+	REQUIRE_NO_FAIL(create_res);
+
+	::fivetran_sdk::v2::TestRequest request;
+	request.set_name(config_tester::TEST_DATABASE_TYPE);
+	auto& request_config = *request.mutable_configuration();
+	request_config["motherduck_database"] = db_name;
+	request_config["motherduck_token"] = MD_TOKEN;
+	request_config["strict_primary_keys"] = "true";
+
+	DestinationSdkImpl service;
+	::fivetran_sdk::v2::TestResponse response;
+	const auto status = service.Test(nullptr, &request, &response);
+
+	CHECK_NO_FAIL(con->Query("DROP DATABASE " + db_name));
+
+	REQUIRE_NO_FAIL(status);
+	CAPTURE(response.failure());
+	REQUIRE_THAT(response.failure(), Catch::Matchers::ContainsSubstring("Strict primary keys cannot be enabled when using a Ducklake database"));
 }
 
 TEST_CASE("Test config tester for max_record_size values", "[integration][configtest]") {

--- a/test/integration/test_config_tester.cpp
+++ b/test/integration/test_config_tester.cpp
@@ -105,7 +105,8 @@ TEST_CASE("Test fails when motherduck_database is a share", "[integration][confi
 	REQUIRE_THAT(response.failure(), Catch::Matchers::ContainsSubstring("is a read-only MotherDuck share"));
 }
 
-TEST_CASE("Test fails when motherduck_database is Ducklake and strict primary keys are enabled", "[integration][configtest]") {
+TEST_CASE("Test fails when motherduck_database is Ducklake and strict primary keys are enabled",
+          "[integration][configtest]") {
 	auto con = get_test_connection(MD_TOKEN);
 	ensure_workspace_mode(*con);
 
@@ -128,7 +129,8 @@ TEST_CASE("Test fails when motherduck_database is Ducklake and strict primary ke
 
 	REQUIRE_NO_FAIL(status);
 	CAPTURE(response.failure());
-	REQUIRE_THAT(response.failure(), Catch::Matchers::ContainsSubstring("Strict primary keys cannot be enabled when using a Ducklake database"));
+	REQUIRE_THAT(response.failure(), Catch::Matchers::ContainsSubstring(
+	                                     "Strict primary keys cannot be enabled when using a Ducklake database"));
 }
 
 TEST_CASE("Test config tester for max_record_size values", "[integration][configtest]") {

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -19,10 +19,11 @@ TEST_CASE("ConfigurationForm", "[integration][config]") {
 	auto status = service.ConfigurationForm(nullptr, &request, &response);
 	REQUIRE_NO_FAIL(status);
 
-	REQUIRE(response.fields_size() == 3);
+	REQUIRE(response.fields_size() == 4);
 	REQUIRE(response.fields(0).name() == "motherduck_token");
 	REQUIRE(response.fields(1).name() == "motherduck_database");
 	REQUIRE(response.fields(2).name() == "max_record_size");
+	REQUIRE(response.fields(2).name() == "strict_primary_keys");
 
 	REQUIRE(response.tests_size() == 4);
 }

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -23,7 +23,7 @@ TEST_CASE("ConfigurationForm", "[integration][config]") {
 	REQUIRE(response.fields(0).name() == "motherduck_token");
 	REQUIRE(response.fields(1).name() == "motherduck_database");
 	REQUIRE(response.fields(2).name() == "max_record_size");
-	REQUIRE(response.fields(2).name() == "strict_primary_keys");
+	REQUIRE(response.fields(3).name() == "strict_primary_keys");
 
 	REQUIRE(response.tests_size() == 4);
 }


### PR DESCRIPTION
We are going to move to opt-in primary key constraints. This PR adds a new toggle field to the configuration form of the MotherDuck Fivetran connector that allows users to switch back to enforcing unique primary keys.

The option is disabled by default when configuring the connector. If the property is not found in the configuration, this indicates that the configuration was created before this new option was introduced and should therefore resolve to `true`.

I have to double-check with Fivetran how toggle fields are serialized. For now I assumed we receive the strings `"true`/`"false"`, but I haven't found anything about this in the docs.