### PR TITLE
`ALTER TABLE` (recreate) bug fixes

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -249,7 +249,8 @@ private:
 	void run_query(duckdb::Connection& con, const std::string& log_prefix, const std::string& query,
 	               const std::string& error_message) const;
 	void alter_table_recreate(duckdb::Connection& con, const table_def& table,
-	                          const std::vector<column_def>& all_columns_in_new_table, const std::set<std::string>& common_columns);
+	                          const std::vector<column_def>& all_columns_in_new_table,
+	                          const std::set<std::string>& existing_columns_in_new_table);
 	void check_no_duplicate_primary_keys(duckdb::Connection& con, const table_def& table,
 	                                     const std::vector<column_def>& all_columns_in_new_table,
 	                                     const std::set<std::string>& existing_columns_in_new_table) const;

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -513,13 +513,27 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 	bool recreate_table = false;
 
 	auto absolute_table_name = table.to_escaped_string();
-	std::set<std::string> alter_types;
+
+	// `existing` means "currently in the
+	// destination table" (from describe_table), `requested` means "named in the
+	// AlterTable request".
+	//
+	// requested, not existing -> added_columns
+	// not requested, existing -> deleted_columns if drop_columns, else retained_columns
+	// requested and existing  -> retained_columns, plus alter_types when the type
+	//                            changed
+
 	std::set<std::string> added_columns;
+	// Columns will only be inserted into deleted_columns if drop_columns == true
 	std::set<std::string> deleted_columns;
-	std::set<std::string> common_columns;
+	// Columns are retained if they are part of the requested columns or drop_columns == false
+	std::set<std::string> retained_columns;
+	// Columns with changed types. Used for the alter-in-place path only.
+	std::set<std::string> alter_types;
 
 	logger.info("    in MdSqlGenerator::alter_table for " + absolute_table_name);
 	const auto& existing_columns = describe_table(con, table);
+	// The requested columns by name, for lookups against the existing ones.
 	std::map<std::string, column_def> new_column_map;
 
 	// start by assuming all columns are new
@@ -532,14 +546,15 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 	for (const auto& col : existing_columns) {
 		const auto& new_col_it = new_column_map.find(col.name);
 
-		if (added_columns.erase(col.name)) {
-			common_columns.emplace(col.name);
-		}
+		// Every existing column is kept unless the drop below claims it.
+		added_columns.erase(col.name);
+		retained_columns.emplace(col.name);
 
 		if (new_col_it == new_column_map.end()) {
 			if (drop_columns) { // Only drop physical columns if drop_columns is true
 				                // (from the alter table request)
 				deleted_columns.emplace(col.name);
+				retained_columns.erase(col.name);
 
 				if (col.primary_key) {
 					recreate_table = true;
@@ -584,23 +599,22 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 
 	if (recreate_table) {
 		logger.info("    recreating table");
-		// preserve the order of the original columns
-		auto all_columns = existing_columns;
-
-		// replace definitions of existing columns with the new ones if available
-		for (size_t i = 0; i < all_columns.size(); i++) {
-			const auto& new_col_it = new_column_map.find(all_columns[i].name);
-			if (new_col_it != new_column_map.end()) {
-				all_columns[i] = new_col_it->second;
+		// Rebuild the column list in the original order: leave out the deleted
+		// columns, apply the updated definitions for the ones that remain, then
+		// append the newly added columns in the order the request lists them.
+		std::vector<column_def> all_columns;
+		all_columns.reserve(existing_columns.size() - deleted_columns.size() + added_columns_ordered.size());
+		for (const auto& col : existing_columns) {
+			if (deleted_columns.find(col.name) != deleted_columns.end()) {
+				continue;
 			}
+			const auto new_col_it = new_column_map.find(col.name);
+			all_columns.push_back(new_col_it != new_column_map.end() ? new_col_it->second : col);
 		}
-
-		// add new columns to the end of the table, in order they appear in the
-		// request
 		for (const auto& col : added_columns_ordered) {
 			all_columns.push_back(col);
 		}
-		alter_table_recreate(con, table, all_columns, common_columns);
+		alter_table_recreate(con, table, all_columns, retained_columns);
 	} else {
 		logger.info("    altering table in place");
 		alter_table_in_place(con, table, added_columns_ordered, deleted_columns, alter_types, new_column_map);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(integration_tests
         test_memory_backed_file.cpp
         test_md_error.cpp
         test_process_file.cpp
+        test_alter_table.cpp
         test_helpers.cpp
         integration/common.cpp
         integration/test_config_tester.cpp

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -837,14 +837,13 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 	}
 
 	{
-
 		// Make sure the defaults are set correctly
 		auto res = con->Query("SELECT * FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == "1");
 		REQUIRE(res->GetValue(1, 0) == "one");
-		REQUIRE(res->GetValue(2, 0) == 0);            // id_new that did not get deleted
+		REQUIRE(res->GetValue(2, 0) == 101);          // id_new that was kept, value and all
 		REQUIRE(res->GetValue(3, 0) == 0);            // id_int that got added
 		REQUIRE(res->GetValue(4, 0) == "");           // id_varchar that got added
 		REQUIRE(res->GetValue(5, 0) == "1970-01-01"); // id_date that got added
@@ -891,7 +890,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 		REQUIRE(res->RowCount() == 2);
 		REQUIRE(res->GetValue(0, 0) == "1");
 		REQUIRE(res->GetValue(1, 0) == "one");
-		REQUIRE(res->GetValue(2, 0) == 0);
+		REQUIRE(res->GetValue(2, 0) == 101); // id_new keeps its value across this recreate too
 		REQUIRE(res->GetValue(3, 0) == 0);
 		REQUIRE(res->GetValue(4, 0) == "");
 		REQUIRE(res->GetValue(5, 0) == "1970-01-01");

--- a/test/test_alter_table.cpp
+++ b/test/test_alter_table.cpp
@@ -1,0 +1,70 @@
+#include "duckdb.hpp"
+#include "integration/common.hpp"
+#include "md_logging.hpp"
+#include "schema_types.hpp"
+#include "sql_generator.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+TEST_CASE("AlterTable recreate preserves data in columns the request omits if drop_columns=false", "[alter]") {
+	// "Deleted" columns are retained with drop_columns=false and their data must be carried over to the recreated
+	// table.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+
+	const table_def table {"memory", "main", "t"};
+	REQUIRE_NO_FAIL(
+	    con.Query("CREATE TABLE t (\"id\" INTEGER, \"v\" VARCHAR, \"to_be_deleted\" INTEGER, PRIMARY KEY (\"id\"))"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 42)"));
+
+	// "extra" is absent from the request. The widened primary key triggers a recreate.
+	constexpr std::vector<column_def> requested = {
+	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
+	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
+	    column_def {.name = "new_col", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true}};
+	generator.alter_table(con, table, requested, /*drop_columns=*/false);
+
+	// "to_be_deleted" column is still there
+	const auto columns = generator.describe_table(con, table);
+	REQUIRE(columns.size() == 4);
+	REQUIRE(columns[2].name == "to_be_deleted");
+
+	auto res = con.Query("SELECT \"id\", \"v\", \"to_be_deleted\" FROM t");
+	REQUIRE_NO_FAIL(res);
+	REQUIRE(res->RowCount() == 1);
+	check_row(res, 0, {duckdb::Value::INTEGER(1), "a", duckdb::Value::INTEGER(42)});
+}
+
+TEST_CASE("AlterTable recreate drops the columns the request drops if drop_columns=true", "[alter]") {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+
+	const table_def table {"memory", "main", "t"};
+	REQUIRE_NO_FAIL(
+	    con.Query("CREATE TABLE t (\"id\" INTEGER, \"v\" VARCHAR, \"to_be_deleted\" VARCHAR, PRIMARY KEY (\"id\"))"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 'remove-me')"));
+
+	// "obsolete" is absent from the request and drop_columns allows dropping it,
+	// so the recreated table must not carry it over.
+	const std::vector<column_def> requested = {
+	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
+	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
+	    column_def {.name = "new_col", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true}};
+	generator.alter_table(con, table, requested, /*drop_columns=*/true);
+
+	const auto columns = generator.describe_table(con, table);
+	REQUIRE(columns.size() == 3);
+	for (const auto& column : columns) {
+		REQUIRE(column.name != "to_be_deleted");
+	}
+
+	auto res = con.Query("SELECT \"id\", \"v\" FROM t");
+	REQUIRE_NO_FAIL(res);
+	REQUIRE(res->RowCount() == 1);
+	check_row(res, 0, {duckdb::Value::INTEGER(1), "a"});
+}

--- a/test/test_alter_table.cpp
+++ b/test/test_alter_table.cpp
@@ -16,8 +16,7 @@ TEST_CASE("AlterTable recreate preserves data in columns the request omits if dr
 	MdSqlGenerator generator(logger);
 
 	const table_def table {"memory", "main", "t"};
-	REQUIRE_NO_FAIL(
-	    con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 42)"));
 
 	// "to_be_deleted" is absent from the request. The widened primary key triggers a recreate.
@@ -45,8 +44,7 @@ TEST_CASE("AlterTable recreate drops the columns the request drops if drop_colum
 	MdSqlGenerator generator(logger);
 
 	const table_def table {"memory", "main", "t"};
-	REQUIRE_NO_FAIL(
-	    con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted VARCHAR)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted VARCHAR)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 'remove-me')"));
 
 	// "obsolete" is absent from the request and drop_columns allows dropping it,

--- a/test/test_alter_table.cpp
+++ b/test/test_alter_table.cpp
@@ -20,8 +20,8 @@ TEST_CASE("AlterTable recreate preserves data in columns the request omits if dr
 	    con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 42)"));
 
-	// "extra" is absent from the request. The widened primary key triggers a recreate.
-	constexpr std::vector<column_def> requested = {
+	// "to_be_deleted" is absent from the request. The widened primary key triggers a recreate.
+	const std::vector<column_def> requested = {
 	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
 	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
 	    column_def {.name = "new_col", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true}};

--- a/test/test_alter_table.cpp
+++ b/test/test_alter_table.cpp
@@ -17,7 +17,7 @@ TEST_CASE("AlterTable recreate preserves data in columns the request omits if dr
 
 	const table_def table {"memory", "main", "t"};
 	REQUIRE_NO_FAIL(
-	    con.Query("CREATE TABLE t (\"id\" INTEGER, \"v\" VARCHAR, \"to_be_deleted\" INTEGER, PRIMARY KEY (\"id\"))"));
+	    con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 42)"));
 
 	// "extra" is absent from the request. The widened primary key triggers a recreate.
@@ -32,7 +32,7 @@ TEST_CASE("AlterTable recreate preserves data in columns the request omits if dr
 	REQUIRE(columns.size() == 4);
 	REQUIRE(columns[2].name == "to_be_deleted");
 
-	auto res = con.Query("SELECT \"id\", \"v\", \"to_be_deleted\" FROM t");
+	auto res = con.Query("SELECT id, v, to_be_deleted FROM t");
 	REQUIRE_NO_FAIL(res);
 	REQUIRE(res->RowCount() == 1);
 	check_row(res, 0, {duckdb::Value::INTEGER(1), "a", duckdb::Value::INTEGER(42)});
@@ -46,7 +46,7 @@ TEST_CASE("AlterTable recreate drops the columns the request drops if drop_colum
 
 	const table_def table {"memory", "main", "t"};
 	REQUIRE_NO_FAIL(
-	    con.Query("CREATE TABLE t (\"id\" INTEGER, \"v\" VARCHAR, \"to_be_deleted\" VARCHAR, PRIMARY KEY (\"id\"))"));
+	    con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted VARCHAR)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 'remove-me')"));
 
 	// "obsolete" is absent from the request and drop_columns allows dropping it,
@@ -63,7 +63,7 @@ TEST_CASE("AlterTable recreate drops the columns the request drops if drop_colum
 		REQUIRE(column.name != "to_be_deleted");
 	}
 
-	auto res = con.Query("SELECT \"id\", \"v\" FROM t");
+	auto res = con.Query("SELECT id, v FROM t");
 	REQUIRE_NO_FAIL(res);
 	REQUIRE(res->RowCount() == 1);
 	check_row(res, 0, {duckdb::Value::INTEGER(1), "a"});


### PR DESCRIPTION
Fixes two bugs:
1. When `drop_columns == false` and the table got recreated, we added the "virtually dropped" column to the new table but did not copy its data with the `INSERT INTO` statement in `alter_table_recreate`. Specifically, `common_columns` contained all the columns of the existing table that are also part of the new table definition – hence, it did not contain deleted columns. The `INSERT INTO` statement was built based on `common_columns`.
  Now, `common_columns` has been renamed to `retained_columns` and contains deleted columns as well iff `drop_columns == false`. Therefore, the data of the dropped column will be retained.
2. When `drop_columns == true` and the table got recreated, we added the dropped columns back in the new table. `all_columns` was built from _every_ existing column and then passed to `alter_table_recreate`. The columns in the `deleted_columns` are now not added to `all_columns` anymore.

Context:
https://github.com/fivetran/fivetran_partner_sdk/blob/3f7ec297106e32da941c3f6b563504185fb84a55/development-guide/destination-connector-development-guide.md?plain=1#L113
> `dropColumns`: A boolean indicating whether to drop columns not in the `AlterTable` request. When `false`, no columns should be dropped even if the columns in the request differ from those present in the destination table, preventing unintended data loss. When `true`, operation should drop columns present in the destination but absent from the request. `dropColumns` is set to `true` only when a schema migration operation calls `AlterTable`.