### PR TITLE
Recreate table when `ALTER TABLE` narrows primary key even with `drop_columns==false`

### DIFF
--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -514,15 +514,12 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 
 	auto absolute_table_name = table.to_escaped_string();
 
-	// `existing` means "currently in the
-	// destination table" (from describe_table), `requested` means "named in the
+	// `existing` means "currently in the destination table" (from describe_table), `requested` means "named in the
 	// AlterTable request".
 	//
 	// requested, not existing -> added_columns
 	// not requested, existing -> deleted_columns if drop_columns, else retained_columns
-	// requested and existing  -> retained_columns, plus alter_types when the type
-	//                            changed
-
+	// requested and existing  -> retained_columns, plus alter_types when the type changed
 	std::set<std::string> added_columns;
 	// Columns will only be inserted into deleted_columns if drop_columns == true
 	std::set<std::string> deleted_columns;
@@ -551,14 +548,16 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 		retained_columns.emplace(col.name);
 
 		if (new_col_it == new_column_map.end()) {
-			if (drop_columns) { // Only drop physical columns if drop_columns is true
-				                // (from the alter table request)
+			// If a primary key column is dropped, we recreate the table and change the primary key, even if
+			// drop_columns == false and the physical column stays in the table.
+			if (col.primary_key) {
+				recreate_table = true;
+			}
+
+			if (drop_columns) {
+				// Only drop physical column if drop_columns is true
 				deleted_columns.emplace(col.name);
 				retained_columns.erase(col.name);
-
-				if (col.primary_key) {
-					recreate_table = true;
-				}
 			} else {
 				logger.info("Source connector requested that table " + absolute_table_name + " column " + col.name +
 				            " be dropped, but dropping columns is not allowed when "
@@ -609,7 +608,16 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 				continue;
 			}
 			const auto new_col_it = new_column_map.find(col.name);
-			all_columns.push_back(new_col_it != new_column_map.end() ? new_col_it->second : col);
+			if (new_col_it != new_column_map.end()) {
+				// Column is still present in new table definition. Use new column definition.
+				all_columns.push_back(new_col_it->second);
+			} else {
+				// Retained because drop_columns is false. Keep the column and its data,
+				// but not its primary key membership.
+				column_def retained = col;
+				retained.primary_key = false;
+				all_columns.push_back(retained);
+			}
 		}
 		for (const auto& col : added_columns_ordered) {
 			all_columns.push_back(col);

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -783,8 +783,8 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 	}
 
 	{
-		// Alter Table to drop a primary key column -- should be a no-op as dropping
-		// columns is not allowed
+		// Alter Table to drop a primary key column. The column itself survives, as
+		// dropping columns is not allowed, but it stops being part of the primary key.
 		::fivetran_sdk::v2::AlterTableRequest request;
 
 		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
@@ -804,7 +804,8 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 		REQUIRE(response.table().columns_size() == 3);
 		check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
 		check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, true);
-		check_column(response, 2, "id_new", ::fivetran_sdk::v2::DataType::INT, true);
+		// Kept, but no longer a key column: the request no longer lists it.
+		check_column(response, 2, "id_new", ::fivetran_sdk::v2::DataType::INT, false);
 	}
 
 	{
@@ -876,7 +877,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 		REQUIRE(response.table().columns_size() == 7);
 		check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
 		check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, true);
-		check_column(response, 2, "id_new", ::fivetran_sdk::v2::DataType::INT, true);
+		check_column(response, 2, "id_new", ::fivetran_sdk::v2::DataType::INT, false);
 		check_column(response, 3, "id_int", ::fivetran_sdk::v2::DataType::LONG, false); // this type got updated
 		check_column(response, 4, "id_varchar", ::fivetran_sdk::v2::DataType::STRING, true);
 		check_column(response, 5, "id_date", ::fivetran_sdk::v2::DataType::NAIVE_DATE, true);
@@ -1472,8 +1473,9 @@ TEST_CASE("AlterTable must not drop columns unless specified", "[integration]") 
 	verifyTableStructure(true);
 
 	{
-		// Alter Table to drop a primary key column -- no-op because columns must
-		// not be deleted
+		// Alter Table to drop a primary key column -- the column itself is retained
+		// because columns must not be deleted, but it stops being a key column,
+		// which recreates the table
 		::fivetran_sdk::v2::AlterTableRequest request;
 
 		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
@@ -1485,13 +1487,12 @@ TEST_CASE("AlterTable must not drop columns unless specified", "[integration]") 
 		REQUIRE_NO_FAIL(status);
 	}
 
-	verifyTableStructure(true);
+	verifyTableStructure(false); // "id" lost its key status; the column is still there
 
 	{
-		// Alter Table to change the type on a primary key column and drop the
-		// regular column Still no-op but needs a separate test because changing
-		// primary key status results in table recreation, so could accidentally
-		// cause a column to be dropped
+		// Alter Table sending the (by now regular) primary key column and dropping
+		// the regular column. Still a no-op, but needs a separate test because a
+		// recreate could accidentally cause a column to be dropped
 		::fivetran_sdk::v2::AlterTableRequest request;
 
 		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);

--- a/test/test_alter_table.cpp
+++ b/test/test_alter_table.cpp
@@ -5,7 +5,23 @@
 #include "sql_generator.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <string>
 #include <vector>
+
+namespace {
+// The names of the key columns among <columns>, in table order.
+std::vector<std::string> primary_key_names(const std::vector<column_def>& columns) {
+	std::vector<const column_def*> columns_pk;
+	find_primary_keys(columns, columns_pk);
+
+	std::vector<std::string> names;
+	names.reserve(columns_pk.size());
+	for (const auto* col : columns_pk) {
+		names.push_back(col->name);
+	}
+	return names;
+}
+} // namespace
 
 TEST_CASE("AlterTable recreate preserves data in columns the request omits if drop_columns=false", "[alter]") {
 	// "Deleted" columns are retained with drop_columns=false and their data must be carried over to the recreated
@@ -47,8 +63,8 @@ TEST_CASE("AlterTable recreate drops the columns the request drops if drop_colum
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, v VARCHAR, to_be_deleted VARCHAR)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'a', 'remove-me')"));
 
-	// "obsolete" is absent from the request and drop_columns allows dropping it,
-	// so the recreated table must not carry it over.
+	// "to_be_deleted" is absent from the request and drop_columns allows dropping
+	// it, so the recreated table must not carry it over.
 	const std::vector<column_def> requested = {
 	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
 	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
@@ -65,4 +81,36 @@ TEST_CASE("AlterTable recreate drops the columns the request drops if drop_colum
 	REQUIRE_NO_FAIL(res);
 	REQUIRE(res->RowCount() == 1);
 	check_row(res, 0, {duckdb::Value::INTEGER(1), "a"});
+}
+
+TEST_CASE("AlterTable removes the constraints of columns the request omits if drop_columns=false", "[alter]") {
+	// A column the request no longer contains must not stay part of the primary
+	// key, or WriteBatch's ON CONFLICT would no longer match it.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+
+	const table_def table {"memory", "main", "t"};
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t (id INTEGER, region VARCHAR, v VARCHAR, PRIMARY KEY (id, region))"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'us', 'a'), (2, 'eu', 'b')"));
+
+	// "region" is absent from the request. Narrowing the primary key is the only
+	// reason to recreate here.
+	const std::vector<column_def> requested = {
+	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
+	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR}};
+	generator.alter_table(con, table, requested, /*drop_columns=*/false);
+
+	REQUIRE(primary_key_names(generator.describe_table(con, table)) == std::vector<std::string> {"id"});
+
+	// The column and its data are still there ...
+	auto res = con.Query("SELECT id, region, v FROM t ORDER BY id");
+	REQUIRE_NO_FAIL(res);
+	REQUIRE(res->RowCount() == 2);
+	check_row(res, 0, {duckdb::Value::INTEGER(1), "us", "a"});
+	check_row(res, 1, {duckdb::Value::INTEGER(2), "eu", "b"});
+
+	// ... but it no longer rejects NULL.
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t (id, v) VALUES (3, 'c')"));
 }


### PR DESCRIPTION
A column that is absent from the requested columns in an "Alter Table" request does not get deleted iff `drop_columns == false`. However, it should still be removed from the primary key if it was previously part of it. This is necessary because newly inserted data will provide `NULL` values for this column, but those would be rejected because of the `NOT NULL` constraint, and the primary key in `WriteBatch` would not match anymore.

This PR forces a recreation of the table whenever the primary key is narrowed, even if `drop_columns == false`.