### PR TITLE
Add lenient "NotNull" primary key mode

### DIFF
--- a/includes/request_context.hpp
+++ b/includes/request_context.hpp
@@ -4,6 +4,7 @@
 #include "duckdb.hpp"
 #include "google/protobuf/map.h"
 #include "md_logging.hpp"
+#include "schema_types.hpp"
 
 #include <string>
 
@@ -27,11 +28,17 @@ public:
 	const std::string& GetDBName() const {
 		return db_name;
 	}
+	/// How primary keys should be enforced for the current request, as configured
+	/// by the "Strict Primary Keys" property
+	PrimaryKeyMode GetPrimaryKeyMode() const {
+		return pk_mode;
+	}
 
 private:
 	std::string endpoint_name;
 	std::string db_name;
 	std::string md_token;
+	PrimaryKeyMode pk_mode;
 	duckdb::Connection con;
 	// Logger has to have a shorter lifetime than the connection
 	mdlog::Logger logger;

--- a/includes/schema_types.hpp
+++ b/includes/schema_types.hpp
@@ -12,6 +12,11 @@ constexpr std::uint8_t DECIMAL_DEFAULT_SCALE = 3;
 constexpr std::uint8_t DECIMAL_MIN_WIDTH = 1;
 constexpr std::uint8_t DECIMAL_MAX_WIDTH = 38;
 
+/// Two types of constraints for primary key columns:
+/// - NotNull: primary key columns are declared NOT NULL only (no uniqueness).
+/// - Strict: primary key columns are declared PRIMARY KEY (NOT NULL + UNIQUE)
+enum class PrimaryKeyMode { NotNull, Strict };
+
 struct column_def {
 	std::string name;
 	duckdb::LogicalTypeId type = duckdb::LogicalTypeId::INVALID;

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -11,6 +11,15 @@
 #include <string>
 #include <vector>
 
+/// Selects the key columns of a table into `columns_pk` (and, if provided, the
+/// remaining columns into `columns_regular`).
+///
+/// Invariant: a "key column" is exactly a column whose `column_def.primary_key`
+/// is set. On the wire this comes from Fivetran; on readback `describe_table()`
+/// reconstructs it from `NOT is_nullable`, because the connector marks its key
+/// columns (and only those) NOT NULL. `ignored_primary_key` lets callers exclude
+/// a column that is a key in the destination but should not be treated as one
+/// here (used for `_fivetran_start` in history mode).
 void find_primary_keys(const std::vector<column_def>& cols, std::vector<const column_def*>& columns_pk,
                        std::vector<const column_def*>* columns_regular = nullptr,
                        const std::string& ignored_primary_key = "");
@@ -88,18 +97,21 @@ public:
 
 	bool table_exists(duckdb::Connection& con, const table_def& table) const;
 
+	bool table_has_unique_primary_key(duckdb::Connection& con, const table_def& table) const;
+
 	void create_table(duckdb::Connection& con, const table_def& table, const std::vector<column_def>& all_columns,
-	                  const std::set<std::string>& columns_with_default_value);
+	                  const std::set<std::string>& columns_with_default_value, PrimaryKeyMode pk_mode);
 
 	std::vector<column_def> describe_table(duckdb::Connection& con, const table_def& table);
 	void add_column(duckdb::Connection& con, const table_def& table, const column_def& column,
-	                const std::string& log_prefix, bool ignore_if_exists = false) const;
+	                const std::string& log_prefix, bool ignore_if_exists = false,
+	                bool default_is_sql_literal = false) const;
 
 	void drop_column(duckdb::Connection& con, const table_def& table, const std::string& column_name,
 	                 const std::string& log_prefix, bool not_exists_ok = false) const;
 
 	void alter_table(duckdb::Connection& con, const table_def& table, const std::vector<column_def>& requested_columns,
-	                 bool drop_columns);
+	                 bool drop_columns, PrimaryKeyMode pk_mode);
 
 	void upsert(duckdb::Connection& con, const table_def& table, const std::string& staging_table_name,
 	            const std::vector<const column_def*>& columns_pk,
@@ -157,7 +169,8 @@ public:
 
 	// Copy a table in the destination.
 	void copy_table(duckdb::Connection& con, const table_def& from_table, const table_def& to_table,
-	                const std::string& log_prefix, const std::vector<const column_def*>& additional_pks = {});
+	                const std::string& log_prefix, PrimaryKeyMode pk_mode,
+	                const std::vector<const column_def*>& additional_pks = {});
 
 	// Copy a column in the destination.
 	void copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column_name,
@@ -168,7 +181,7 @@ public:
 	// soft_deleted_column is not empty, we try to retain historic info as much as
 	// we can.
 	void copy_table_to_history_mode(duckdb::Connection& con, const table_def& from_table, const table_def& to_table,
-	                                const std::string& soft_deleted_column);
+	                                const std::string& soft_deleted_column, PrimaryKeyMode pk_mode);
 
 	// Rename a destination table
 	void rename_table(duckdb::Connection& con, const table_def& from_table, const std::string& to_table_name,
@@ -209,23 +222,27 @@ public:
 	// timestamp respectively for active rows, because we interpret the latest
 	// sync as the initial insert into the historic table.
 	void migrate_soft_delete_to_history(duckdb::Connection& con, const table_def& original_table,
-	                                    const std::string& soft_deleted_column);
+	                                    const std::string& soft_deleted_column, PrimaryKeyMode pk_mode);
 	void add_defaults(duckdb::Connection& con, const std::vector<column_def>& columns, const table_def& table,
 	                  const std::string& log_prefix);
-	void add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk, const table_def& table,
-	             const std::string& log_prefix) const;
+
+	// Adds PRIMARY KEY (strict mode) or NOT NULL (NotNull mode) constraint to primary key columns.
+	void apply_primary_key_constraint(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk,
+	                                  const table_def& table, const std::string& log_prefix,
+	                                  PrimaryKeyMode pk_mode) const;
 
 	// Switch between sync modes: history to soft-delete. This means keeping only
 	// the last entries based on per MAX("_fivetran_start") per primary key,
 	// setting the soft_deleted_column values to "NOT _fivetran_active" and
 	// dropping the unused history mode columns.
 	void migrate_history_to_soft_delete(duckdb::Connection& con, const table_def& table,
-	                                    const std::string& soft_deleted_column);
+	                                    const std::string& soft_deleted_column, PrimaryKeyMode pk_mode);
 
 	// Switch between sync modes: history to live. This means only keeping the
 	// rows that are active as indicated by
 	// "_fivetran_active".
-	void migrate_history_to_live(duckdb::Connection& con, const table_def& table, bool keep_deleted_rows);
+	void migrate_history_to_live(duckdb::Connection& con, const table_def& table, bool keep_deleted_rows,
+	                             PrimaryKeyMode pk_mode);
 
 	// Switch between sync modes: live to soft-delete. In general live-mode does
 	// not keep track of deletions, in which case just adds we want to set the
@@ -241,21 +258,28 @@ public:
 	// this just adds the needed history-mode columns and sets sane defaults: all
 	// rows are active, _fivetran_start = NOW() and _fivetran_end is the maximum
 	// timestamp possible.
-	void migrate_live_to_history(duckdb::Connection& con, const table_def& table);
+	void migrate_live_to_history(duckdb::Connection& con, const table_def& table, PrimaryKeyMode pk_mode);
 
 private:
 	mdlog::Logger& logger;
 
 	void run_query(duckdb::Connection& con, const std::string& log_prefix, const std::string& query,
 	               const std::string& error_message) const;
+
+	void set_not_null(duckdb::Connection& con, const table_def& table, const std::string& column_name, bool not_null,
+	                  const std::string& log_prefix) const;
 	void alter_table_recreate(duckdb::Connection& con, const table_def& table,
 	                          const std::vector<column_def>& all_columns_in_new_table,
-	                          const std::set<std::string>& existing_columns_in_new_table);
+	                          const std::set<std::string>& existing_columns_in_new_table, PrimaryKeyMode pk_mode);
 	void check_no_duplicate_primary_keys(duckdb::Connection& con, const table_def& table,
 	                                     const std::vector<column_def>& all_columns_in_new_table,
 	                                     const std::set<std::string>& existing_columns_in_new_table) const;
+	// `key_added`/`key_removed` name existing columns whose key membership changed
+	// (used only in NotNull mode to toggle NOT NULL in place).
 	void alter_table_in_place(duckdb::Connection& con, const table_def& table,
 	                          const std::vector<column_def>& added_columns,
 	                          const std::set<std::string>& deleted_columns, const std::set<std::string>& alter_types,
-	                          const std::map<std::string, column_def>& new_column_map);
+	                          const std::map<std::string, column_def>& new_column_map,
+	                          const std::set<std::string>& key_added, const std::set<std::string>& key_removed,
+	                          PrimaryKeyMode pk_mode);
 };

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -291,7 +291,7 @@ grpc::Status DestinationSdkImpl::CreateTable(::grpc::ServerContext*,
 
 		const table_def table {ctx->GetDBName(), schema_name, request->table().name()};
 		const auto cols = get_duckdb_columns(request->table().columns());
-		sql_generator->create_table(con, table, cols, {});
+		sql_generator->create_table(con, table, cols, {}, ctx->GetPrimaryKeyMode());
 		response->set_success(true);
 	} catch (const md_error::RecoverableError& mde) {
 		logger.warning("CreateTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
@@ -325,7 +325,7 @@ grpc::Status DestinationSdkImpl::AlterTable(::grpc::ServerContext*,
 
 		auto sql_generator = std::make_unique<MdSqlGenerator>(logger);
 		sql_generator->alter_table(con, table_name, get_duckdb_columns(request->table().columns()),
-		                           request->drop_columns());
+		                           request->drop_columns(), ctx->GetPrimaryKeyMode());
 		response->set_success(true);
 	} catch (const md_error::RecoverableError& mde) {
 		logger.severe("AlterTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
@@ -587,6 +587,7 @@ grpc::Status DestinationSdkImpl::WriteBatch(::grpc::ServerContext*,
 			                        .max_record_size = max_record_size};
 
 			csv_processor::ProcessFile(con, props, logger, [&](const std::string& staging_table_name) {
+				// In history mode, we always append a new row, so it is genuinely insert, not upsert.
 				sql_generator->insert(con, table_name, staging_table_name, columns_pk, columns_regular);
 			});
 		}
@@ -744,7 +745,7 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 				const auto& copy_table = copy.copy_table();
 				table_def from_table {db_name, schema_name, copy_table.from_table()};
 				table_def to_table {db_name, schema_name, copy_table.to_table()};
-				sql_generator->copy_table(con, from_table, to_table, "copy_table");
+				sql_generator->copy_table(con, from_table, to_table, "copy_table", ctx->GetPrimaryKeyMode());
 				break;
 			}
 			case fivetran_sdk::v2::CopyOperation::EntityCase::kCopyColumn: {
@@ -763,7 +764,8 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 				const auto& copy_hist = copy.copy_table_to_history_mode();
 				table_def from_table {db_name, schema_name, copy_hist.from_table()};
 				table_def to_table {db_name, schema_name, copy_hist.to_table()};
-				sql_generator->copy_table_to_history_mode(con, from_table, to_table, copy_hist.soft_deleted_column());
+				sql_generator->copy_table_to_history_mode(con, from_table, to_table, copy_hist.soft_deleted_column(),
+				                                          ctx->GetPrimaryKeyMode());
 				break;
 			}
 			default: {
@@ -881,15 +883,17 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 				break;
 			case fivetran_sdk::v2::SOFT_DELETE_TO_HISTORY:
 				logger.info("Endpoint <Migrate>: SOFT_DELETE_TO_HISTORY");
-				sql_generator->migrate_soft_delete_to_history(con, table, soft_deleted_column);
+				sql_generator->migrate_soft_delete_to_history(con, table, soft_deleted_column,
+				                                              ctx->GetPrimaryKeyMode());
 				break;
 			case fivetran_sdk::v2::HISTORY_TO_SOFT_DELETE:
 				logger.info("Endpoint <Migrate>: HISTORY_TO_SOFT_DELETE");
-				sql_generator->migrate_history_to_soft_delete(con, table, soft_deleted_column);
+				sql_generator->migrate_history_to_soft_delete(con, table, soft_deleted_column,
+				                                              ctx->GetPrimaryKeyMode());
 				break;
 			case fivetran_sdk::v2::HISTORY_TO_LIVE:
 				logger.info("Endpoint <Migrate>: HISTORY_TO_LIVE");
-				sql_generator->migrate_history_to_live(con, table, keep_deleted_rows);
+				sql_generator->migrate_history_to_live(con, table, keep_deleted_rows, ctx->GetPrimaryKeyMode());
 				break;
 			case fivetran_sdk::v2::LIVE_TO_SOFT_DELETE:
 				logger.info("Endpoint <Migrate>: LIVE_TO_SOFT_DELETE");
@@ -897,7 +901,7 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 				break;
 			case fivetran_sdk::v2::LIVE_TO_HISTORY:
 				logger.info("Endpoint <Migrate>: LIVE_TO_HISTORY");
-				sql_generator->migrate_live_to_history(con, table);
+				sql_generator->migrate_live_to_history(con, table, ctx->GetPrimaryKeyMode());
 				break;
 			default:
 				response->set_unsupported(true);

--- a/src/request_context.cpp
+++ b/src/request_context.cpp
@@ -16,6 +16,11 @@ mdlog::Logger get_logger_for_env(duckdb::Connection& con) {
 	}
 	return mdlog::Logger::CreateMultiSinkLogger(&con);
 }
+
+PrimaryKeyMode get_pk_mode(const google::protobuf::Map<std::string, std::string>& request_config) {
+	const bool strict = config::find_bool_property(request_config, config::PROP_STRICT_PRIMARY_KEYS, false);
+	return strict ? PrimaryKeyMode::Strict : PrimaryKeyMode::NotNull;
+}
 } // namespace
 
 RequestContext::RequestContext(const std::string& endpoint_name_, ConnectionFactory& connection_factory,
@@ -23,6 +28,7 @@ RequestContext::RequestContext(const std::string& endpoint_name_, ConnectionFact
     : endpoint_name(endpoint_name_),
       db_name(config::find_property(request_config, config::PROP_DATABASE)),
       md_token(config::find_property(request_config, config::PROP_TOKEN)),
+      pk_mode(get_pk_mode(request_config)),
       con(connection_factory.CreateConnection(md_token, db_name)),
       logger(get_logger_for_env(con)) {
 	logger.debug("Endpoint <" + endpoint_name + "> started");

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -6,6 +6,7 @@
 #include "md_logging.hpp"
 #include "schema_types.hpp"
 
+#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <fmt/format.h>
@@ -91,7 +92,7 @@ std::string make_full_column_list(const std::vector<const column_def*>& columns_
 	return full_column_list.str();
 }
 
-std::string primary_key_join(std::vector<const column_def*>& columns_pk, const std::string tbl1,
+std::string primary_key_join(const std::vector<const column_def*>& columns_pk, const std::string tbl1,
                              const std::string tbl2) {
 	return join(columns_pk, " AND ", [&tbl1, &tbl2](std::ostream& out, const column_def* col) {
 		const auto quoted = col->quoted();
@@ -152,6 +153,26 @@ bool MdSqlGenerator::table_exists(duckdb::Connection& con, const table_def& tabl
 	const std::string err_prefix = "Could not find whether table <" + table.to_escaped_string() + "> exists";
 	logger.debug("table_exists: " + std::string(query) + ", database_name=" + table.db_name +
 	             ", schema_name=" + table.schema_name + ", table_name=" + table.table_name);
+	const auto statement = con.Prepare(query);
+	if (statement->HasError()) {
+		throw std::runtime_error(err_prefix + " (at bind step): " + statement->GetError());
+	}
+	duckdb::vector<duckdb::Value> params = {duckdb::Value(table.db_name), duckdb::Value(table.schema_name),
+	                                        duckdb::Value(table.table_name)};
+	auto result = statement->Execute(params, false);
+	if (result->HasError()) {
+		result->ThrowError(err_prefix);
+	}
+	const auto materialized_result =
+	    duckdb::unique_ptr_cast<duckdb::QueryResult, duckdb::MaterializedQueryResult>(std::move(result));
+	return materialized_result->RowCount() > 0;
+}
+
+bool MdSqlGenerator::table_has_unique_primary_key(duckdb::Connection& con, const table_def& table) const {
+	const std::string query = "SELECT 1 FROM duckdb_constraints() WHERE "
+	                          "database_name=? AND schema_name=? AND table_name=? AND constraint_type='PRIMARY KEY'";
+	const std::string err_prefix =
+	    "Could not check for a primary key constraint on <" + table.to_escaped_string() + ">";
 	const auto statement = con.Prepare(query);
 	if (statement->HasError()) {
 		throw std::runtime_error(err_prefix + " (at bind step): " + statement->GetError());
@@ -244,7 +265,8 @@ std::string get_default_value(duckdb::LogicalTypeId type) {
 
 void MdSqlGenerator::create_table(duckdb::Connection& con, const table_def& table,
                                   const std::vector<column_def>& all_columns,
-                                  const std::set<std::string>& columns_with_default_value) {
+                                  const std::set<std::string>& columns_with_default_value,
+                                  const PrimaryKeyMode pk_mode) {
 	const std::string absolute_table_name = table.to_escaped_string();
 
 	std::vector<const column_def*> columns_pk;
@@ -258,11 +280,17 @@ void MdSqlGenerator::create_table(duckdb::Connection& con, const table_def& tabl
 		if (columns_with_default_value.find(col.name) != columns_with_default_value.end()) {
 			ddl << " DEFAULT " + get_default_value(col.type);
 		}
+		// Key columns are always NOT NULL: in NotNull mode that is the only thing
+		// marking them as such, and in Strict mode the PRIMARY KEY below implies it
+		// anyway. This is what describe_table() relies on to recover the key set.
+		if (col.primary_key) {
+			ddl << " NOT NULL";
+		}
 
 		ddl << ", "; // DuckDB allows trailing commas
 	}
 
-	if (!columns_pk.empty()) {
+	if (!columns_pk.empty() && pk_mode == PrimaryKeyMode::Strict) {
 		ddl << "PRIMARY KEY (";
 		join(ddl, columns_pk, to_name);
 		ddl << ")";
@@ -335,7 +363,8 @@ std::vector<column_def> MdSqlGenerator::describe_table(duckdb::Connection& con, 
 }
 
 void MdSqlGenerator::add_column(duckdb::Connection& con, const table_def& table, const column_def& column,
-                                const std::string& log_prefix, const bool ignore_if_exists) const {
+                                const std::string& log_prefix, const bool ignore_if_exists,
+                                const bool default_is_sql_literal) const {
 	// Add `column` to `table` and add a default value if present in the struct.
 	std::ostringstream sql;
 	sql << "ALTER TABLE " << table.to_escaped_string() << " ADD COLUMN ";
@@ -347,13 +376,22 @@ void MdSqlGenerator::add_column(duckdb::Connection& con, const table_def& table,
 	sql << KeywordHelper::WriteQuoted(column.name, '"') << " " << format_type(column);
 
 	if (column.column_default.has_value()) {
-		if (column.column_default.value() == "NULL") {
-			logger.info("Detected string \"NULL\" as default value for column " + column.name);
+		// default_is_sql_literal says that it already is a valid SQL literal for that type (as produced by get_default_value()).
+		if (default_is_sql_literal) {
+			// No cast if we set the default to a literal. DuckDB rewrites the ALTER statement if the default is not a ConstantExpression, and a CastExpression is not.
+			// It would be rewritten to `ALTER TABLE t ADD COLUMN c DEFAULT NULL` + `UPDATE t SET c = <expr>` + `ALTER TABLE t ALTER c SET DEFAULT <expr>`.
+			// The problem with this is that after that, in a multi-statement transaction, a subsequent `ALTER COLUMN c SET NOT NULL` statement would fail with a TransactionContextException.
+			sql << " DEFAULT " << column.column_default.value();
+		} else {
+			if (column.column_default.value() == "NULL") {
+				logger.info("Detected string \"NULL\" as default value for column " + column.name);
+			}
+			// We should not expect NULLs here according to fivetran, so we also cast
+			// the string "NULL" to the string "NULL" for varchar columns, not NULLs.
+			sql << " DEFAULT CAST(" << KeywordHelper::WriteQuoted(column.column_default.value(), '\'') << " AS "
+				<< format_type(column) << ")";
 		}
-		// We should not expect NULLs here according to fivetran, so we also cast
-		// the string "NULL" to the string "NULL" for varchar columns, not NULLs.
-		sql << " DEFAULT CAST(" << KeywordHelper::WriteQuoted(column.column_default.value(), '\'') << " AS "
-		    << format_type(column) << ")";
+
 	}
 
 	return run_query(con, log_prefix, sql.str(),
@@ -435,10 +473,13 @@ void MdSqlGenerator::check_no_duplicate_primary_keys(duckdb::Connection& con, co
 
 void MdSqlGenerator::alter_table_recreate(duckdb::Connection& con, const table_def& table,
                                           const std::vector<column_def>& all_columns_in_new_table,
-                                          const std::set<std::string>& existing_columns_in_new_table) {
-	// Bail out before any DDL if the new primary key would not be unique over the
-	// existing data; the surrounding transaction rolls back cleanly on throw.
-	check_no_duplicate_primary_keys(con, table, all_columns_in_new_table, existing_columns_in_new_table);
+                                          const std::set<std::string>& existing_columns_in_new_table,
+                                          const PrimaryKeyMode pk_mode) {
+	// Only in strict mode the new key needs to be unique over the existing data.
+	// In NotNull mode, duplicates are tolerated. It is the source's responsibility to deduplicate data if desired.
+	if (pk_mode == PrimaryKeyMode::Strict) {
+		check_no_duplicate_primary_keys(con, table, all_columns_in_new_table, existing_columns_in_new_table);
+	}
 
 	long timestamp =
 	    std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
@@ -457,7 +498,7 @@ void MdSqlGenerator::alter_table_recreate(duckdb::Connection& con, const table_d
 		}
 	}
 
-	create_table(con, table, all_columns_in_new_table, new_primary_key_cols);
+	create_table(con, table, all_columns_in_new_table, new_primary_key_cols, pk_mode);
 
 	// reinsert the data from the old table
 	std::ostringstream out_column_list;
@@ -485,9 +526,30 @@ void MdSqlGenerator::alter_table_in_place(duckdb::Connection& con, const table_d
                                           const std::vector<column_def>& added_columns,
                                           const std::set<std::string>& deleted_columns,
                                           const std::set<std::string>& alter_types,
-                                          const std::map<std::string, column_def>& new_column_map) {
+                                          const std::map<std::string, column_def>& new_column_map,
+                                          const std::set<std::string>& key_added,
+                                          const std::set<std::string>& key_removed, const PrimaryKeyMode pk_mode) {
+
 	for (const auto& col : added_columns) {
-		add_column(con, table, col, "alter_table add");
+		// Adding a primary key column with PrimaryKeyMode::Strict would imply that alter_table_recreate gets called.
+		assert(!col.primary_key || pk_mode == PrimaryKeyMode::NotNull);
+		std::ignore = pk_mode;
+
+		// AlterTables request don't carry default values
+		assert(!col.column_default.has_value());
+
+		// A newly added key column must end up NOT NULL, so the existing rows need a
+		// value for it.
+		column_def column_to_add = col;
+		if (col.primary_key) {
+			column_to_add.column_default = get_default_value(col.type);
+		}
+		add_column(con, table, column_to_add, "alter_table add", /*ignore_if_exists=*/false,
+		           /*default_is_sql_literal=*/col.primary_key);
+
+		if (col.primary_key) {
+			set_not_null(con, table, col.name, true, "alter_table add set_not_null");
+		}
 	}
 
 	auto absolute_table_name = table.to_escaped_string();
@@ -503,15 +565,25 @@ void MdSqlGenerator::alter_table_in_place(duckdb::Connection& con, const table_d
 		          "Could not alter type for column <" + col_name + "> in table <" + absolute_table_name + ">");
 	}
 
+	// Toggle NOT NULL constraint for existing columns whose key membership changed.
+	// Note that, if the primary key changed, we are always in PrimaryKeyMode::NotNull here.
+	// Otherwise, alter_table_recreate would have been called.
+	assert(pk_mode == PrimaryKeyMode::NotNull || (key_added.empty() && key_removed.empty()));
+	for (const auto& col_name : key_added) {
+		set_not_null(con, table, col_name, true, "alter_table set_not_null");
+	}
+	for (const auto& col_name : key_removed) {
+		set_not_null(con, table, col_name, false, "alter_table drop_not_null");
+	}
+
 	for (const auto& col_name : deleted_columns) {
 		drop_column(con, table, col_name, "alter_table drop", false);
 	}
 }
 
 void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table,
-                                 const std::vector<column_def>& requested_columns, const bool drop_columns) {
-	bool recreate_table = false;
-
+                                 const std::vector<column_def>& requested_columns, const bool drop_columns,
+                                 const PrimaryKeyMode pk_mode) {
 	auto absolute_table_name = table.to_escaped_string();
 
 	// `existing` means "currently in the destination table" (from describe_table), `requested` means "named in the
@@ -527,6 +599,13 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 	std::set<std::string> retained_columns;
 	// Columns with changed types. Used for the alter-in-place path only.
 	std::set<std::string> alter_types;
+	// Existing columns whose key membership changed; consumed in place in NotNull
+	// mode (empty in Strict mode, where key changes trigger a recreate).
+	std::set<std::string> key_columns_added;
+	std::set<std::string> key_columns_removed;
+	// True if the key set changes at all (a key column added, removed, or
+	// dropped). Only Strict mode reacts by recreating the table.
+	bool key_changed = false;
 
 	logger.info("    in MdSqlGenerator::alter_table for " + absolute_table_name);
 	const auto& existing_columns = describe_table(con, table);
@@ -551,7 +630,7 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 			// If a primary key column is dropped, we recreate the table and change the primary key, even if
 			// drop_columns == false and the physical column stays in the table.
 			if (col.primary_key) {
-				recreate_table = true;
+				key_changed = true;
 			}
 
 			if (drop_columns) {
@@ -559,32 +638,65 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 				deleted_columns.emplace(col.name);
 				retained_columns.erase(col.name);
 			} else {
+				// The column stays, but it is no longer a primary key column, so NotNull
+				// mode has to drop its NOT NULL. Without this describe_table() would keep
+				// reporting the column as a primary key.
+				if (col.primary_key) {
+					key_columns_removed.emplace(col.name);
+				}
+
 				logger.info("Source connector requested that table " + absolute_table_name + " column " + col.name +
 				            " be dropped, but dropping columns is not allowed when "
 				            "drop_columns is false");
 			}
-		} else if (new_col_it->second.primary_key != col.primary_key) {
-			logger.info("Altering primary key requested for column <" + new_col_it->second.name + ">");
-			recreate_table = true;
-		} else if (new_col_it->second.type != col.type ||
-		           (new_col_it->second.type == duckdb::LogicalTypeId::DECIMAL &&
-		            (new_col_it->second.scale != col.scale || new_col_it->second.width != col.width))) {
-			alter_types.emplace(col.name);
+		} else {
+			// The column exists on both sides. Its key membership and its type can
+			// change in the same request, so both have to be checked independently.
+			if (new_col_it->second.primary_key && !col.primary_key) {
+				// The column joins the primary key. Tracked separately from the removal
+				// below so NotNull mode can set NOT NULL on it in place.
+				logger.info("Adding column <" + col.name + "> to the primary key");
+				key_changed = true;
+				key_columns_added.emplace(col.name);
+			} else if (!new_col_it->second.primary_key && col.primary_key) {
+				// The column leaves the primary key, so NotNull mode drops its NOT NULL.
+				logger.info("Removing column <" + col.name + "> from the primary key");
+				key_changed = true;
+				key_columns_removed.emplace(col.name);
+			}
+
+			if (new_col_it->second.type != col.type ||
+			    (new_col_it->second.type == duckdb::LogicalTypeId::DECIMAL &&
+			     (new_col_it->second.scale != col.scale || new_col_it->second.width != col.width))) {
+				alter_types.emplace(col.name);
+			}
 		}
 	}
+
+	// Find new columns that are part of the primary key.
+	std::vector<std::string> added_key_columns;
+	for (const auto& column_name : added_columns) {
+		if (new_column_map.at(column_name).primary_key) {
+			added_key_columns.push_back(column_name);
+		}
+	}
+	if (!added_key_columns.empty()) {
+		logger.info("Adding column(s) <" + join(added_key_columns) + "> to the primary key");
+		key_changed = true;
+	}
+
+	// A PRIMARY KEY constraint cannot be altered or dropped in place, hence we need to recreate the table in strict
+	// primary key mode. If the table still carries a primary key constraint from before switching to NotNull mode, we
+	// also recreate the table. Otherwise, in NotNull mode, we do not need to recreate the table because we can run SET NOT NULL/DROP NOT NULL in place.
+	// Lastly, if the user switched from NotNull to Strict mode, we also recreate the table.
+	const bool table_has_pks = table_has_unique_primary_key(con, table);
+	const bool must_shed_legacy_pks = pk_mode == PrimaryKeyMode::NotNull && table_has_pks;
+	const bool has_switched_to_strict_mode = pk_mode == PrimaryKeyMode::Strict && !table_has_pks;
+	const bool recreate_table = (key_changed && pk_mode == PrimaryKeyMode::Strict) || (key_changed && has_switched_to_strict_mode || must_shed_legacy_pks;
 	logger.info("    inventoried columns; recreate_table = " + std::to_string(recreate_table) +
 	            "; num alter_types = " + std::to_string(alter_types.size()));
 
-	auto primary_key_added_it =
-	    std::find_if(added_columns.begin(), added_columns.end(), [&new_column_map](const std::string& column_name) {
-		    return new_column_map[column_name].primary_key;
-	    });
-	if (primary_key_added_it != added_columns.end()) {
-		logger.info("Adding primary key requested for column <" + *primary_key_added_it + ">");
-		recreate_table = true;
-	}
-
-	// list added columns in order
+	// list added columns in order. Assumes that requested_columns is in the correct order.
 	std::vector<column_def> added_columns_ordered;
 	for (const auto& col : requested_columns) {
 		const auto& new_col_it = added_columns.find(col.name);
@@ -622,10 +734,11 @@ void MdSqlGenerator::alter_table(duckdb::Connection& con, const table_def& table
 		for (const auto& col : added_columns_ordered) {
 			all_columns.push_back(col);
 		}
-		alter_table_recreate(con, table, all_columns, retained_columns);
+		alter_table_recreate(con, table, all_columns, retained_columns, pk_mode);
 	} else {
 		logger.info("    altering table in place");
-		alter_table_in_place(con, table, added_columns_ordered, deleted_columns, alter_types, new_column_map);
+		alter_table_in_place(con, table, added_columns_ordered, deleted_columns, alter_types, new_column_map,
+		                     key_columns_added, key_columns_removed, pk_mode);
 	}
 
 	transaction_context.Commit();
@@ -635,22 +748,36 @@ void MdSqlGenerator::upsert(duckdb::Connection& con, const table_def& table, con
                             const std::vector<const column_def*>& columns_pk,
                             const std::vector<const column_def*>& columns_regular) {
 
-	auto full_column_list = make_full_column_list(columns_pk, columns_regular);
 	const std::string absolute_table_name = table.to_escaped_string();
+
+	// Fivetran guarantees a primary key for every synced table, but stay
+	// defensive: without key columns there is nothing to match on, so fall back
+	// to a plain insert (matching the historical behaviour of this method).
+	assert(!columns_pk.empty());
+
+	std::vector<const column_def*> all_columns;
+	all_columns.reserve(columns_pk.size() + columns_regular.size());
+	all_columns.insert(all_columns.end(), columns_pk.begin(), columns_pk.end());
+	all_columns.insert(all_columns.end(), columns_regular.begin(), columns_regular.end());
+
+	// We use MERGE INTO because it does not require a PRIMARY KEY constraint on the merge columns, in contrast to INSERT INTO ... ON CONFLICT.
 	std::ostringstream sql;
-	sql << "INSERT INTO " << absolute_table_name << "(" << full_column_list << ") SELECT " << full_column_list
-	    << " FROM " << staging_table_name;
+	sql << "MERGE INTO " << absolute_table_name << " AS target USING " << staging_table_name << " AS source ON "
+	    << primary_key_join(columns_pk, "target", "source");
 
-	if (!columns_pk.empty()) {
-		sql << " ON CONFLICT (";
-		join(sql, columns_pk, to_name);
-		sql << " ) DO UPDATE SET ";
-
+	if (!columns_regular.empty()) {
+		sql << " WHEN MATCHED THEN UPDATE SET ";
 		join(sql, columns_regular, [](std::ostream& out, const column_def* column) {
 			const auto quoted_col = column->quoted();
-			out << quoted_col << " = excluded." << quoted_col;
+			out << quoted_col << " = source." << quoted_col;
 		});
 	}
+
+	sql << " WHEN NOT MATCHED THEN INSERT (";
+	join(sql, all_columns, to_name);
+	sql << ") VALUES (";
+	join(sql, all_columns, [](std::ostream& out, const column_def* column) { out << "source." << column->quoted(); });
+	sql << ")";
 
 	auto query = sql.str();
 	logger.info("upsert: " + query);
@@ -1021,7 +1148,8 @@ void MdSqlGenerator::drop_column_in_history_mode(duckdb::Connection& con, const 
 }
 
 void MdSqlGenerator::copy_table(duckdb::Connection& con, const table_def& from_table, const table_def& to_table,
-                                const std::string& log_prefix, const std::vector<const column_def*>& additional_pks) {
+                                const std::string& log_prefix, const PrimaryKeyMode pk_mode,
+                                const std::vector<const column_def*>& additional_pks) {
 	TransactionContext transaction_context(con);
 
 	{
@@ -1045,7 +1173,7 @@ void MdSqlGenerator::copy_table(duckdb::Connection& con, const table_def& from_t
 	combined_pks.insert(combined_pks.end(), additional_pks.begin(), additional_pks.end());
 
 	add_defaults(con, columns, to_table, log_prefix);
-	add_pks(con, combined_pks, to_table, log_prefix);
+	apply_primary_key_constraint(con, combined_pks, to_table, log_prefix, pk_mode);
 
 	transaction_context.Commit();
 }
@@ -1074,8 +1202,10 @@ void MdSqlGenerator::add_defaults(duckdb::Connection& con, const std::vector<col
 	}
 }
 
-void MdSqlGenerator::add_pks(duckdb::Connection& con, const std::vector<const column_def*>& columns_pk,
-                             const table_def& table, const std::string& log_prefix) const {
+void MdSqlGenerator::apply_primary_key_constraint(duckdb::Connection& con,
+                                                  const std::vector<const column_def*>& columns_pk,
+                                                  const table_def& table, const std::string& log_prefix,
+                                                  const PrimaryKeyMode pk_mode) const {
 	if (columns_pk.empty()) {
 		// All modes require a primary key to be present, because we cannot switch
 		// to history mode without a primary key. Fivetran has confirmed that the
@@ -1084,14 +1214,48 @@ void MdSqlGenerator::add_pks(duckdb::Connection& con, const std::vector<const co
 		throw std::runtime_error("No primary keys found for table " + table.to_escaped_string());
 	}
 
-	// Add the right primary key. Note that "CREATE TABLE AS SELECT" does not
-	// add any primary key constraints.
-	std::ostringstream sql;
+	// Note that "CREATE TABLE AS SELECT" does not carry over any constraints, so
+	// the key columns have to be (re)marked here.
+	if (pk_mode == PrimaryKeyMode::Strict) {
+		std::ostringstream sql;
+		sql << "ALTER TABLE " << table.to_escaped_string() << " ADD PRIMARY KEY (";
+		join(sql, columns_pk, to_name);
+		sql << ");";
+		run_query(con, log_prefix, sql.str(), "Could not add pks to table " + table.to_escaped_string());
+	} else {
+		for (const auto& col : columns_pk) {
+			set_not_null(con, table, col->name, true, log_prefix);
+		}
+	}
+}
 
-	sql << "ALTER TABLE " << table.to_escaped_string() << " ADD PRIMARY KEY (";
-	join(sql, columns_pk, to_name);
-	sql << ");";
-	run_query(con, log_prefix, sql.str(), "Could not add pks to table " + table.to_escaped_string());
+void MdSqlGenerator::set_not_null(duckdb::Connection& con, const table_def& table, const std::string& column_name,
+                                  const bool not_null, const std::string& log_prefix) const {
+	std::ostringstream sql;
+	sql << "ALTER TABLE " << table.to_escaped_string() << " ALTER COLUMN "
+	    << KeywordHelper::WriteQuoted(column_name, '"') << (not_null ? " SET NOT NULL" : " DROP NOT NULL");
+
+	const auto query = sql.str();
+	logger.info(log_prefix + ": " + query);
+	const auto result = con.Query(query);
+	if (!result->HasError()) {
+		return;
+	}
+
+	const std::string& error_msg = result->GetError();
+
+	// An existing column can only join the primary key if every row has a value
+	// for it. Only the source can resolve that, so hand the user a task rather
+	// than failing the sync with a bare constraint error.
+	if (not_null && error_msg.find("NOT NULL constraint failed") != std::string::npos) {
+		throw md_error::RecoverableError(
+		    "Column \"" + column_name + "\" of " + table.schema_name + "." + table.table_name +
+		    " cannot be made part of the primary key because it contains NULL values. To proceed, populate or "
+		    "remove the rows where it is NULL, or drop the table and trigger a historical re-sync.");
+	}
+
+	throw std::runtime_error("Could not " + std::string(not_null ? "set" : "drop") + " NOT NULL on column <" +
+	                         column_name + "> of table <" + table.to_escaped_string() + ">: " + error_msg);
 }
 
 void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table, const std::string& from_column_name,
@@ -1141,19 +1305,20 @@ void MdSqlGenerator::copy_column(duckdb::Connection& con, const table_def& table
 }
 
 void MdSqlGenerator::copy_table_to_history_mode(duckdb::Connection& con, const table_def& from_table,
-                                                const table_def& to_table, const std::string& soft_deleted_column) {
+                                                const table_def& to_table, const std::string& soft_deleted_column,
+                                                const PrimaryKeyMode pk_mode) {
 	const std::string from_table_name = from_table.to_escaped_string();
 	const std::string to_table_name = to_table.to_escaped_string();
 
 	// This already runs inside a transaction.
 	// There is no need to add _fivetran_start as an additional primary key at
 	// this point, as that happens in the migrate_*_to_history() below.
-	copy_table(con, from_table, to_table, "copy_table_to_history_mode copy_table");
+	copy_table(con, from_table, to_table, "copy_table_to_history_mode copy_table", pk_mode);
 
 	if (!soft_deleted_column.empty()) {
-		migrate_soft_delete_to_history(con, to_table, soft_deleted_column);
+		migrate_soft_delete_to_history(con, to_table, soft_deleted_column, pk_mode);
 	} else {
-		migrate_live_to_history(con, to_table);
+		migrate_live_to_history(con, to_table, pk_mode);
 	}
 }
 
@@ -1323,7 +1488,8 @@ void MdSqlGenerator::migrate_soft_delete_to_live(duckdb::Connection& con, const 
 }
 
 void MdSqlGenerator::migrate_soft_delete_to_history(duckdb::Connection& con, const table_def& original_table,
-                                                    const std::string& soft_deleted_column) {
+                                                    const std::string& soft_deleted_column,
+                                                    const PrimaryKeyMode pk_mode) {
 	const std::string absolute_table_name = original_table.to_escaped_string();
 	const std::string quoted_deleted_col = KeywordHelper::WriteQuoted(soft_deleted_column, '"');
 
@@ -1383,7 +1549,7 @@ void MdSqlGenerator::migrate_soft_delete_to_history(duckdb::Connection& con, con
 		column_def fivetran_start {.name = "_fivetran_start", .type = duckdb::LogicalTypeId::TIMESTAMP_TZ};
 		additional_pks.push_back(&fivetran_start);
 
-		copy_table(con, temp_table, original_table, "migrate_soft_delete_to_history copy", additional_pks);
+		copy_table(con, temp_table, original_table, "migrate_soft_delete_to_history copy", pk_mode, additional_pks);
 		drop_table(con, temp_table, "migrate_soft_delete_to_history drop");
 
 		transaction_context.Commit();
@@ -1391,7 +1557,8 @@ void MdSqlGenerator::migrate_soft_delete_to_history(duckdb::Connection& con, con
 }
 
 void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, const table_def& table,
-                                                    const std::string& soft_deleted_column) {
+                                                    const std::string& soft_deleted_column,
+                                                    const PrimaryKeyMode pk_mode) {
 	const std::string quoted_deleted_col = KeywordHelper::WriteQuoted(soft_deleted_column, '"');
 
 	TransactionContext transaction_context(con);
@@ -1459,7 +1626,7 @@ void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, con
 		}
 	}
 	add_defaults(con, new_columns, temp_table, "migrate_history_to_soft_delete set_default");
-	add_pks(con, columns_pk, temp_table, "migrate_history_to_soft_delete set_pk");
+	apply_primary_key_constraint(con, columns_pk, temp_table, "migrate_history_to_soft_delete set_pk", pk_mode);
 
 	// Swap the original and temporary table
 	drop_table(con, table, "migrate_history_to_soft_delete drop");
@@ -1468,7 +1635,8 @@ void MdSqlGenerator::migrate_history_to_soft_delete(duckdb::Connection& con, con
 	transaction_context.Commit();
 }
 
-void MdSqlGenerator::migrate_history_to_live(duckdb::Connection& con, const table_def& table, bool keep_deleted_rows) {
+void MdSqlGenerator::migrate_history_to_live(duckdb::Connection& con, const table_def& table, bool keep_deleted_rows,
+                                             const PrimaryKeyMode pk_mode) {
 	const std::string absolute_table_name = table.to_escaped_string();
 
 	TransactionContext transaction_context(con);
@@ -1513,7 +1681,8 @@ void MdSqlGenerator::migrate_history_to_live(duckdb::Connection& con, const tabl
 	add_defaults(con, new_columns, temp_table, "migrate_history_to_live set_default");
 
 	if (!keep_deleted_rows) {
-		add_pks(con, columns_pk, temp_table, "migrate_history_to_live add_pks");
+		apply_primary_key_constraint(con, columns_pk, temp_table, "migrate_history_to_live apply_key_constraint",
+		                             pk_mode);
 	}
 
 	// Swap the original and temporary table
@@ -1546,7 +1715,8 @@ void MdSqlGenerator::migrate_live_to_soft_delete(duckdb::Connection& con, const 
 	transaction_context.Commit();
 }
 
-void MdSqlGenerator::migrate_live_to_history(duckdb::Connection& con, const table_def& table) {
+void MdSqlGenerator::migrate_live_to_history(duckdb::Connection& con, const table_def& table,
+                                             const PrimaryKeyMode pk_mode) {
 	const std::string absolute_table_name = table.to_escaped_string();
 	table_def temp_table {table.db_name, table.schema_name, table.table_name + "_temp"};
 	const std::string temp_absolute_table_name = temp_table.to_escaped_string();
@@ -1589,7 +1759,7 @@ void MdSqlGenerator::migrate_live_to_history(duckdb::Connection& con, const tabl
 	column_def fivetran_start {.name = "_fivetran_start", .type = duckdb::LogicalTypeId::TIMESTAMP_TZ};
 	additional_pks.push_back(&fivetran_start);
 
-	copy_table(con, temp_table, table, "migrate_live_to_history copy", additional_pks);
+	copy_table(con, temp_table, table, "migrate_live_to_history copy", pk_mode, additional_pks);
 	drop_table(con, temp_table, "migrate_live_to_history drop");
 
 	transaction_context.Commit();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(integration_tests
         test_memory_backed_file.cpp
         test_md_error.cpp
         test_process_file.cpp
+        test_merge_into.cpp
         test_alter_table.cpp
         test_helpers.cpp
         integration/common.cpp

--- a/test/integration/common.hpp
+++ b/test/integration/common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../constants.hpp"
+#include "config.hpp"
 #include "duckdb.hpp"
 #include "extension_helper.hpp"
 #include "fivetran_duckdb_interop.hpp"
@@ -203,10 +204,20 @@ void define_history_test_table_reordered(T& request, const std::string& table_na
 	add_col(request, "blob", ::fivetran_sdk::v2::DataType::BINARY, false);
 }
 
+// Sets the "Strict Primary Keys" toggle on any request that carries a
+// configuration map. Passing false is equivalent to leaving it unset (the
+// default), but is explicit in tests.
+template <typename T>
+void set_strict_primary_keys(T& request, bool strict) {
+	(*request.mutable_configuration())[config::PROP_STRICT_PRIMARY_KEYS] = strict ? "true" : "false";
+}
+
 template <std::size_t N>
-void create_table(DestinationSdkImpl& service, const std::string& table_name, const std::array<column_def, N> columns) {
+void create_table(DestinationSdkImpl& service, const std::string& table_name, const std::array<column_def, N> columns,
+                  bool strict_primary_keys = false) {
 	::fivetran_sdk::v2::CreateTableRequest request;
 	add_config(request, test::constants::MD_TOKEN, test::constants::TEST_DATABASE_NAME, table_name);
+	set_strict_primary_keys(request, strict_primary_keys);
 	define_table(request, table_name, columns);
 
 	::fivetran_sdk::v2::CreateTableResponse response;

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -5,6 +5,7 @@
 #include "motherduck_destination_server.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <catch2/internal/catch_run_context.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <fstream>
@@ -24,6 +25,8 @@ TEST_CASE("ConfigurationForm", "[integration][config]") {
 	REQUIRE(response.fields(1).name() == "motherduck_database");
 	REQUIRE(response.fields(2).name() == "max_record_size");
 	REQUIRE(response.fields(3).name() == "strict_primary_keys");
+	REQUIRE(response.fields(3).has_toggle_field());
+	REQUIRE(response.fields(3).default_value() == "false");
 
 	REQUIRE(response.tests_size() == 4);
 }
@@ -104,6 +107,123 @@ TEST_CASE("CreateTable, DescribeTable for existing table, AlterTable", "[integra
 		REQUIRE(response.table().name() == table_name);
 		REQUIRE(response.table().columns_size() == 1);
 		check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::INT, false);
+	}
+}
+
+TEST_CASE("CreateTable in default mode uses NOT NULL without a PRIMARY KEY constraint", "[integration]") {
+	DestinationSdkImpl service;
+	const std::string table_name = "some_table" + std::to_string(randint());
+	auto con = get_test_connection(MD_TOKEN);
+
+	create_table(service, table_name,
+	             std::array {
+	                 column_def {.name = "id", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "name", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "val", .type = duckdb::LogicalTypeId::VARCHAR},
+	             });
+
+	// No uniqueness is enforced in the default mode: the same key can be inserted
+	// twice. (Checked behaviourally rather than through duckdb_constraints(), which
+	// this connection does not necessarily see for a just-created table.)
+	const std::string insert_dup =
+	    "INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name) VALUES ('1', 'a')";
+	REQUIRE_NO_FAIL(con->Query(insert_dup));
+	REQUIRE_NO_FAIL(con->Query(insert_dup));
+	auto count = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
+	REQUIRE_NO_FAIL(count);
+	REQUIRE(count->GetValue(0, 0).GetValue<int64_t>() == 2);
+
+	// The key columns are marked NOT NULL; the non-key column stays nullable.
+	auto not_null = con->Query("SELECT column_name FROM duckdb_columns() WHERE table_name = '" + table_name +
+	                           "' AND NOT is_nullable ORDER BY column_name");
+	REQUIRE_NO_FAIL(not_null);
+	REQUIRE(not_null->RowCount() == 2);
+	REQUIRE(not_null->GetValue(0, 0).ToString() == "id");
+	REQUIRE(not_null->GetValue(0, 1).ToString() == "name");
+
+	// DescribeTable still round-trips the key columns as primary keys.
+	auto response = describe_table(service, table_name);
+	REQUIRE(!response.not_found());
+	check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+	check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, true);
+	check_column(response, 2, "val", ::fivetran_sdk::v2::DataType::STRING, false);
+}
+
+TEST_CASE("CreateTable in strict mode adds an enforced PRIMARY KEY constraint", "[integration]") {
+	DestinationSdkImpl service;
+	const std::string table_name = "some_table" + std::to_string(randint());
+	auto con = get_test_connection(MD_TOKEN);
+
+	create_table(service, table_name,
+	             std::array {
+	                 column_def {.name = "id", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "name", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "val", .type = duckdb::LogicalTypeId::VARCHAR},
+	             },
+	             /*strict_primary_keys=*/true);
+
+	// Uniqueness is enforced by the PRIMARY KEY: inserting a duplicate composite
+	// key fails. This is the observable effect of the constraint, and unlike
+	// duckdb_constraints() it does not depend on this connection's catalog state.
+	auto ins1 = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name) VALUES ('1', 'a')");
+	REQUIRE_NO_FAIL(ins1);
+	auto ins2 = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name + "(id, name) VALUES ('1', 'a')");
+	REQUIRE(ins2->HasError());
+
+	auto response = describe_table(service, table_name);
+	REQUIRE(!response.not_found());
+	check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+	check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, true);
+	check_column(response, 2, "val", ::fivetran_sdk::v2::DataType::STRING, false);
+}
+
+TEST_CASE("WriteBatch upsert works in strict mode", "[integration][write-batch]") {
+	DestinationSdkImpl service;
+	const std::string table_name = "books" + std::to_string(randint());
+	create_table(service, table_name, TEST_COLUMNS, /*strict_primary_keys=*/true);
+
+	auto con = get_test_connection(MD_TOKEN);
+	{
+		// initial insert (same encrypted/compressed fixture as the WriteBatch test)
+		::fivetran_sdk::v2::WriteBatchRequest request;
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME);
+		request.mutable_file_params()->set_encryption(::fivetran_sdk::v2::Encryption::AES);
+		request.mutable_file_params()->set_compression(::fivetran_sdk::v2::Compression::ZSTD);
+		define_table(request, table_name, TEST_COLUMNS);
+		const std::string filepath = TEST_RESOURCES_DIR + "books_batch_1_insert.csv.zst.aes";
+		std::ifstream keyfile(filepath + ".key", std::ios::binary);
+		char key[33];
+		keyfile.read(key, 32);
+		key[32] = 0;
+		(*request.mutable_keys())[filepath] = key;
+		request.add_replace_files(filepath);
+
+		::fivetran_sdk::v2::WriteBatchResponse response;
+		auto status = service.WriteBatch(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+	}
+	{
+		// upsert: updates id=2, inserts id=3 and id=99. Exercises MERGE INTO on a
+		// table that has an enforced PRIMARY KEY.
+		::fivetran_sdk::v2::WriteBatchRequest request;
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME);
+		define_table(request, table_name, TEST_COLUMNS);
+		request.mutable_file_params()->set_null_string("magic-nullvalue");
+		request.add_replace_files(TEST_RESOURCES_DIR + "books_upsert.csv");
+
+		::fivetran_sdk::v2::WriteBatchResponse response;
+		auto status = service.WriteBatch(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+	}
+	{
+		auto res =
+		    con->Query("SELECT id, title, magic_number FROM " + TEST_SCHEMA_NAME + "." + table_name + " ORDER BY id");
+		REQUIRE_NO_FAIL(res);
+		REQUIRE(res->RowCount() == 4);
+		check_row(res, 0, {1, "The Hitchhiker's Guide to the Galaxy", 42});
+		check_row(res, 1, {2, "The Two Towers", 1});
+		check_row(res, 2, {3, "The Hobbit", 14});
+		check_row(res, 3, {99, "null", duckdb::Value()});
 	}
 }
 
@@ -1572,7 +1692,7 @@ TEST_CASE("AlterTable must not drop columns unless specified", "[integration]") 
 	}
 }
 
-TEST_CASE("AlterTable raises a task if a primary key change would create duplicates", "[integration]") {
+TEST_CASE("AlterTable strict mode rejects a non-unique primary key change", "[integration]") {
 	DestinationSdkImpl service;
 
 	const std::string table_name = "some_table" + std::to_string(randint());
@@ -1582,7 +1702,8 @@ TEST_CASE("AlterTable raises a task if a primary key change would create duplica
 	             std::array {
 	                 column_def {.name = "id", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
 	                 column_def {.name = "name", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
-	             });
+	             },
+	             /*strict_primary_keys=*/true);
 
 	{
 		// Two rows that share an "id" but differ on "name". The composite PK
@@ -1593,10 +1714,12 @@ TEST_CASE("AlterTable raises a task if a primary key change would create duplica
 	}
 
 	{
-		// Change the PK to (id, name2), where name2 is a new column, while "id" is not unique
+		// Change the PK to (id, name2), where name2 is a new column, while "id" is not unique.
+		// In strict mode the enforced PRIMARY KEY must stay unique, so this is rejected as a task.
 		::fivetran_sdk::v2::AlterTableRequest request;
 
 		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
+		set_strict_primary_keys(request, true);
 		add_col(request, "id", ::fivetran_sdk::v2::DataType::STRING, true);
 		add_col(request, "name", ::fivetran_sdk::v2::DataType::STRING, false);
 		add_col(request, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
@@ -1622,7 +1745,10 @@ TEST_CASE("AlterTable raises a task if a primary key change would create duplica
 	}
 }
 
-TEST_CASE("AlterTable changes the primary key when the new key stays unique", "[integration]") {
+TEST_CASE("AlterTable default mode allows a non-unique primary key change", "[integration]") {
+	// This is the same scenario as the strict-mode duplicate test, but in the
+	// default NOT NULL mode there is no uniqueness constraint, so re-keying
+	// (id, name) -> (id, name2) succeeds in place even though "id" is not unique.
 	DestinationSdkImpl service;
 
 	const std::string table_name = "some_table" + std::to_string(randint());
@@ -1635,6 +1761,66 @@ TEST_CASE("AlterTable changes the primary key when the new key stays unique", "[
 	             });
 
 	{
+		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
+		                      "(id, name) VALUES ('1', 'a'), ('1', 'b')");
+		REQUIRE_NO_FAIL(res);
+	}
+
+	{
+		::fivetran_sdk::v2::AlterTableRequest request;
+		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
+		add_col(request, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+		add_col(request, "name", ::fivetran_sdk::v2::DataType::STRING, false);
+		add_col(request, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
+
+		::fivetran_sdk::v2::AlterTableResponse response;
+		auto status = service.AlterTable(nullptr, &request, &response);
+		REQUIRE_NO_FAIL(status);
+		REQUIRE(response.success());
+		REQUIRE(!response.has_task());
+	}
+
+	{
+		// Key set is now {id, name2}; both original rows are kept, name2 defaulted.
+		auto response = describe_table(service, table_name);
+		REQUIRE(!response.not_found());
+		REQUIRE(response.table().columns_size() == 3);
+		check_column(response, 0, "id", ::fivetran_sdk::v2::DataType::STRING, true);
+		check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, false);
+		check_column(response, 2, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
+
+		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
+		REQUIRE_NO_FAIL(res);
+		REQUIRE(res->GetValue(0, 0).GetValue<int64_t>() == 2);
+
+		// name2 is a NOT NULL key column with the default empty-string value.
+		const std::string null_query =
+		    "SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name + " WHERE name2 IS NULL";
+		auto null_res = con->Query(null_query);
+		REQUIRE_NO_FAIL(null_res);
+		REQUIRE(null_res->GetValue(0, 0).GetValue<int64_t>() == 0);
+	}
+}
+
+TEST_CASE("AlterTable changes the primary key when the new key stays unique", "[integration]") {
+	// Runs in both modes: strict recreates the table (and its data stays unique on
+	// the new key, so it succeeds), while the default NOT NULL mode does it in place.
+	const bool strict = GENERATE(false, true);
+	CAPTURE(strict);
+
+	DestinationSdkImpl service;
+
+	const std::string table_name = "some_table" + std::to_string(randint());
+
+	auto con = get_test_connection(MD_TOKEN);
+	create_table(service, table_name,
+	             std::array {
+	                 column_def {.name = "id", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	                 column_def {.name = "name", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true},
+	             },
+	             strict);
+
+	{
 		// Distinct "id" values, so dropping "name" from the PK is still unique.
 		auto res = con->Query("INSERT INTO " + TEST_SCHEMA_NAME + "." + table_name +
 		                      "(id, name) VALUES ('1', 'a'), ('2', 'b')");
@@ -1643,10 +1829,11 @@ TEST_CASE("AlterTable changes the primary key when the new key stays unique", "[
 
 	{
 		// Same PK change as the duplicate test, but the existing data keeps the new
-		// key unique, so the recreate should succeed.
+		// key unique, so the change succeeds in both modes.
 		::fivetran_sdk::v2::AlterTableRequest request;
 
 		add_config(request, MD_TOKEN, TEST_DATABASE_NAME, table_name);
+		set_strict_primary_keys(request, strict);
 		add_col(request, "id", ::fivetran_sdk::v2::DataType::STRING, true);
 		add_col(request, "name", ::fivetran_sdk::v2::DataType::STRING, false);
 		add_col(request, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
@@ -1665,7 +1852,7 @@ TEST_CASE("AlterTable changes the primary key when the new key stays unique", "[
 		check_column(response, 1, "name", ::fivetran_sdk::v2::DataType::STRING, false);
 		check_column(response, 2, "name2", ::fivetran_sdk::v2::DataType::STRING, true);
 
-		// The original data is preserved through the recreate.
+		// The original data is preserved through the key change.
 		auto res = con->Query("SELECT COUNT(*) FROM " + TEST_SCHEMA_NAME + "." + table_name);
 		REQUIRE_NO_FAIL(res);
 		REQUIRE(res->GetValue(0, 0).GetValue<int64_t>() == 2);

--- a/test/test_alter_table.cpp
+++ b/test/test_alter_table.cpp
@@ -1,14 +1,63 @@
+// Unit tests for MdSqlGenerator::alter_table, covering both the key-mode paths
+// and which columns survive a recreate. Tables that still carry an enforced
+// PRIMARY KEY -- i.e. created before the connector switched to NOT NULL keys --
+// must be recreated on a key change, because an enforced PK cannot be altered or
+// dropped in place. These run entirely against in-memory DuckDB (no MotherDuck).
+
 #include "duckdb.hpp"
 #include "integration/common.hpp"
+#include "md_error.hpp"
 #include "md_logging.hpp"
 #include "schema_types.hpp"
 #include "sql_generator.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <filesystem>
 #include <string>
 #include <vector>
 
 namespace {
+
+int64_t row_count(duckdb::Connection& con, const std::string& table) {
+	auto res = con.Query("SELECT count(*) FROM " + table);
+	REQUIRE_FALSE(res->HasError());
+	return res->GetValue(0, 0).GetValue<int64_t>();
+}
+
+std::string scalar(duckdb::Connection& con, const std::string& query) {
+	auto res = con.Query(query);
+	REQUIRE_FALSE(res->HasError());
+	return res->GetValue(0, 0).ToString();
+}
+
+void ok(duckdb::Connection& con, const std::string& query) {
+	auto res = con.Query(query);
+	INFO(query);
+	REQUIRE_FALSE(res->HasError());
+}
+
+int64_t primary_key_count(duckdb::Connection& con) {
+	const std::string query =
+	    "SELECT count(*) FROM duckdb_constraints() WHERE table_name = 't' AND constraint_type = 'PRIMARY KEY'";
+	return std::stoll(scalar(con, query));
+}
+
+bool column_is_not_null(duckdb::Connection& con, const std::string& column) {
+	return scalar(con, "SELECT NOT is_nullable FROM duckdb_columns() WHERE table_name = 't' AND column_name = '" +
+	                       column + "'") == "true";
+}
+
+const table_def TABLE {"memory", "main", "t"};
+const std::string QUALIFIED = "\"memory\".\"main\".\"t\"";
+
+column_def key_col(const std::string& name, duckdb::LogicalTypeId type) {
+	return column_def {.name = name, .type = type, .primary_key = true};
+}
+column_def col(const std::string& name, duckdb::LogicalTypeId type) {
+	return column_def {.name = name, .type = type};
+}
+
 // The names of the key columns among <columns>, in table order.
 std::vector<std::string> primary_key_names(const std::vector<column_def>& columns) {
 	std::vector<const column_def*> columns_pk;
@@ -21,7 +70,177 @@ std::vector<std::string> primary_key_names(const std::vector<column_def>& column
 	}
 	return names;
 }
+
 } // namespace
+
+TEST_CASE("AlterTable recreates a legacy PRIMARY KEY table when widening the key (NotNull mode)", "[alter]") {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+	const PrimaryKeyMode pk_mode = PrimaryKeyMode::NotNull;
+
+	// Legacy table from the old connector: enforced PRIMARY KEY on id.
+	ok(con, "CREATE TABLE " + QUALIFIED + " (\"id\" INTEGER, \"v\" VARCHAR, PRIMARY KEY (\"id\"))");
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (1, 'a')");
+
+	// Widen the key to (id, region) by adding a new key column.
+	std::vector<column_def> requested = {key_col("id", duckdb::LogicalTypeId::INTEGER),
+	                                     col("v", duckdb::LogicalTypeId::VARCHAR),
+	                                     key_col("region", duckdb::LogicalTypeId::VARCHAR)};
+	generator.alter_table(con, TABLE, requested, /*drop_columns=*/false, pk_mode);
+
+	// The legacy PK is gone (recreated without one) and the new key column is NOT NULL.
+	REQUIRE(primary_key_count(con) == 0);
+	REQUIRE(column_is_not_null(con, "region"));
+	REQUIRE(column_is_not_null(con, "id"));
+	REQUIRE(row_count(con, QUALIFIED) == 1); // existing row preserved
+
+	// Data non-unique on the OLD pk (id) but unique on the new key now inserts fine.
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (2, 'x', 'us'), (2, 'y', 'eu')");
+	REQUIRE(row_count(con, QUALIFIED) == 3);
+}
+
+TEST_CASE("AlterTable recreates a legacy PRIMARY KEY table when dropping a key column (NotNull mode)", "[alter]") {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+	const PrimaryKeyMode pk_mode = PrimaryKeyMode::NotNull;
+
+	// Legacy composite PRIMARY KEY (id, b).
+	ok(con, "CREATE TABLE " + QUALIFIED + " (\"id\" INTEGER, \"b\" INTEGER, PRIMARY KEY (\"id\", \"b\"))");
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (1, 1)");
+
+	// Drop b (part of the old PK); the key becomes just id.
+	std::vector<column_def> requested = {key_col("id", duckdb::LogicalTypeId::INTEGER)};
+	generator.alter_table(con, TABLE, requested, /*drop_columns=*/true, pk_mode);
+
+	// No Catalog Error; b is gone, the PK is gone, and the row is preserved.
+	REQUIRE(primary_key_count(con) == 0);
+	REQUIRE(scalar(con, "SELECT count(*) FROM duckdb_columns() WHERE table_name = 't' AND column_name = 'b'") == "0");
+	REQUIRE(column_is_not_null(con, "id"));
+	REQUIRE(row_count(con, QUALIFIED) == 1);
+}
+
+TEST_CASE("AlterTable changes the key in place for a NOT NULL table (no PRIMARY KEY, no recreate needed)", "[alter]") {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+	const PrimaryKeyMode pk_mode = PrimaryKeyMode::NotNull;
+
+	// A table created by the new connector: NOT NULL key, no PRIMARY KEY.
+	ok(con, "CREATE TABLE " + QUALIFIED + " (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (1, 'a')");
+
+	std::vector<column_def> requested = {key_col("id", duckdb::LogicalTypeId::INTEGER),
+	                                     col("v", duckdb::LogicalTypeId::VARCHAR),
+	                                     key_col("region", duckdb::LogicalTypeId::VARCHAR)};
+	generator.alter_table(con, TABLE, requested, /*drop_columns=*/false, pk_mode);
+
+	// Still no PRIMARY KEY (we never introduce one in NotNull mode); the new key
+	// column is NOT NULL; the existing row is preserved in place.
+	REQUIRE(primary_key_count(con) == 0);
+	REQUIRE(column_is_not_null(con, "region"));
+	REQUIRE(row_count(con, QUALIFIED) == 1);
+	// Non-unique on id but unique on (id, region) inserts fine.
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (2, 'x', 'us'), (2, 'y', 'eu')");
+	REQUIRE(row_count(con, QUALIFIED) == 3);
+}
+
+TEST_CASE("AlterTable in strict mode rebuilds the PRIMARY KEY on a legacy table's new key", "[alter]") {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+	const PrimaryKeyMode pk_mode = PrimaryKeyMode::Strict;
+
+	ok(con, "CREATE TABLE " + QUALIFIED + " (\"id\" INTEGER, \"v\" VARCHAR, PRIMARY KEY (\"id\"))");
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (1, 'a'), (2, 'b')"); // unique ids -> new key stays unique
+
+	std::vector<column_def> requested = {key_col("id", duckdb::LogicalTypeId::INTEGER),
+	                                     col("v", duckdb::LogicalTypeId::VARCHAR),
+	                                     key_col("region", duckdb::LogicalTypeId::VARCHAR)};
+	generator.alter_table(con, TABLE, requested, /*drop_columns=*/false, pk_mode);
+
+	// Strict mode re-adds an enforced PRIMARY KEY (now over the new key set), so a
+	// duplicate on (id, region) is rejected.
+	REQUIRE(primary_key_count(con) == 1);
+	REQUIRE(row_count(con, QUALIFIED) == 2);
+	auto dup = con.Query("INSERT INTO " + QUALIFIED + " VALUES (1, 'c', '')"); // (1, '') already exists
+	REQUIRE(dup->HasError());
+}
+
+TEST_CASE("AlterTable raises a task when an existing column with NULLs joins the primary key", "[alter]") {
+	// The column can only become NOT NULL if every row has a value, which only the
+	// source can fix, so the connector surfaces a task instead of a raw constraint
+	// error. The failed alter leaves the table untouched.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+	const PrimaryKeyMode pk_mode = PrimaryKeyMode::NotNull;
+
+	ok(con, "CREATE TABLE " + QUALIFIED + " (\"id\" INTEGER NOT NULL, \"region\" VARCHAR)");
+	ok(con, "INSERT INTO " + QUALIFIED + " VALUES (1, 'us'), (2, NULL)"); // region has a NULL
+
+	// Promote the existing, partly-NULL "region" column into the key.
+	std::vector<column_def> requested = {key_col("id", duckdb::LogicalTypeId::INTEGER),
+	                                     key_col("region", duckdb::LogicalTypeId::VARCHAR)};
+
+	// A RecoverableError is what the server turns into a Fivetran task.
+	std::string task_message;
+	try {
+		generator.alter_table(con, TABLE, requested, /*drop_columns=*/false, pk_mode);
+		FAIL("expected a RecoverableError");
+	} catch (const md_error::RecoverableError& e) {
+		task_message = e.what();
+	}
+	REQUIRE_THAT(task_message, Catch::Matchers::ContainsSubstring("contains NULL values"));
+	REQUIRE_THAT(task_message, Catch::Matchers::ContainsSubstring("region"));
+
+	// Rolled back: region is still nullable and both rows survive.
+	REQUIRE_FALSE(column_is_not_null(con, "region"));
+	REQUIRE(row_count(con, QUALIFIED) == 2);
+}
+
+TEST_CASE("DuckLake rejects SET NOT NULL on a table with transaction-local changes", "[alter][ducklake]") {
+	// Documents a DuckLake limitation the NotNull key mode runs into: adding a
+	// column and marking it NOT NULL inside one transaction -- what
+	// alter_table_in_place does for a newly added key column -- is refused, because
+	// DuckLake needs committed column stats to validate the constraint. Skipped
+	// where the ducklake extension is not already available (no download here).
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	if (con.Query("LOAD ducklake")->HasError()) {
+		SKIP("ducklake extension is not available in this environment");
+	}
+
+	const std::string dir_name = "ducklake_notnull_" + duckdb::StringUtil::GenerateRandomName(8);
+	const auto dir = std::filesystem::temp_directory_path() / dir_name;
+	std::filesystem::create_directories(dir);
+	ok(con, "ATTACH 'ducklake:" + (dir / "catalog.ducklake").string() + "' AS lake (DATA_PATH '" +
+	            (dir / "data").string() + "/')");
+
+	ok(con, "CREATE TABLE lake.t (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)"); // NOT NULL at CREATE works
+	ok(con, "INSERT INTO lake.t VALUES (1, 'a')");
+
+	ok(con, "BEGIN TRANSACTION");
+	ok(con, "ALTER TABLE lake.t ADD COLUMN \"region\" VARCHAR DEFAULT ''");
+	auto res = con.Query("ALTER TABLE lake.t ALTER COLUMN \"region\" SET NOT NULL");
+	REQUIRE(res->HasError());
+	REQUIRE_THAT(res->GetError(), Catch::Matchers::ContainsSubstring("SET NOT NULL"));
+	con.Query("ROLLBACK");
+
+	// Committing the ADD COLUMN first makes the same SET NOT NULL succeed, which is
+	// the shape a DuckLake-compatible implementation needs to use.
+	ok(con, "ALTER TABLE lake.t ADD COLUMN \"region2\" VARCHAR DEFAULT ''");
+	ok(con, "ALTER TABLE lake.t ALTER COLUMN \"region2\" SET NOT NULL");
+
+	con.Query("DETACH lake");
+	std::filesystem::remove_all(dir);
+}
 
 TEST_CASE("AlterTable recreate preserves data in columns the request omits if drop_columns=false", "[alter]") {
 	// "Deleted" columns are retained with drop_columns=false and their data must be carried over to the recreated
@@ -40,7 +259,7 @@ TEST_CASE("AlterTable recreate preserves data in columns the request omits if dr
 	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
 	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
 	    column_def {.name = "new_col", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true}};
-	generator.alter_table(con, table, requested, /*drop_columns=*/false);
+	generator.alter_table(con, table, requested, /*drop_columns=*/false, PrimaryKeyMode::Strict);
 
 	// "to_be_deleted" column is still there
 	const auto columns = generator.describe_table(con, table);
@@ -69,7 +288,7 @@ TEST_CASE("AlterTable recreate drops the columns the request drops if drop_colum
 	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
 	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
 	    column_def {.name = "new_col", .type = duckdb::LogicalTypeId::VARCHAR, .primary_key = true}};
-	generator.alter_table(con, table, requested, /*drop_columns=*/true);
+	generator.alter_table(con, table, requested, /*drop_columns=*/true, PrimaryKeyMode::Strict);
 
 	const auto columns = generator.describe_table(con, table);
 	REQUIRE(columns.size() == 3);
@@ -100,7 +319,7 @@ TEST_CASE("AlterTable removes the constraints of columns the request omits if dr
 	const std::vector<column_def> requested = {
 	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
 	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR}};
-	generator.alter_table(con, table, requested, /*drop_columns=*/false);
+	generator.alter_table(con, table, requested, /*drop_columns=*/false, PrimaryKeyMode::Strict);
 
 	REQUIRE(primary_key_names(generator.describe_table(con, table)) == std::vector<std::string> {"id"});
 

--- a/test/test_merge_into.cpp
+++ b/test/test_merge_into.cpp
@@ -1,0 +1,211 @@
+// Unit tests that pin down the DuckDB MERGE INTO semantics the connector's
+// upsert path relies on. These run entirely against an in-memory DuckDB (no
+// MotherDuck), so they double as a regression guard: if a future DuckDB bump
+// changes MERGE behavior, these fail loudly rather than silently corrupting
+// upserts. The SQL shapes here mirror MdSqlGenerator::upsert.
+
+#include "duckdb.hpp"
+#include "md_logging.hpp"
+#include "schema_types.hpp"
+#include "sql_generator.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+namespace {
+
+int64_t row_count(duckdb::Connection& con, const std::string& table) {
+	auto res = con.Query("SELECT count(*) FROM " + table);
+	REQUIRE_FALSE(res->HasError());
+	return res->GetValue(0, 0).GetValue<int64_t>();
+}
+
+std::string scalar(duckdb::Connection& con, const std::string& query) {
+	auto res = con.Query(query);
+	REQUIRE_FALSE(res->HasError());
+	return res->GetValue(0, 0).ToString();
+}
+
+void ok(duckdb::Connection& con, const std::string& query) {
+	auto res = con.Query(query);
+	INFO(query);
+	REQUIRE_FALSE(res->HasError());
+}
+
+// Mirrors the MERGE that MdSqlGenerator::upsert emits: match on the key columns,
+// update the regular columns on a match, insert the full row otherwise.
+const char* UPSERT_MERGE = R"(
+MERGE INTO t AS target USING staging AS source ON target."id" = source."id"
+  WHEN MATCHED THEN UPDATE SET "v" = source."v"
+  WHEN NOT MATCHED THEN INSERT ("id", "v") VALUES (source."id", source."v")
+)";
+
+} // namespace
+
+TEST_CASE("MERGE upserts: matched rows update, unmatched rows insert", "[merge]") {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO t VALUES (1, 'old')");
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 'new'), (2, 'inserted')");
+
+	ok(con, UPSERT_MERGE);
+
+	REQUIRE(row_count(con, "t") == 2);
+	REQUIRE(scalar(con, "SELECT v FROM t WHERE id = 1") == "new");      // matched -> updated
+	REQUIRE(scalar(con, "SELECT v FROM t WHERE id = 2") == "inserted"); // unmatched -> inserted
+}
+
+TEST_CASE("MERGE upsert is idempotent when the same batch is retried", "[merge]") {
+	// A retried WriteBatch replays the same staging rows. Because MERGE matches
+	// on the key, the second run updates the already-present rows instead of
+	// duplicating them.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 'a'), (2, 'b')");
+
+	ok(con, UPSERT_MERGE);
+	REQUIRE(row_count(con, "t") == 2);
+
+	ok(con, UPSERT_MERGE); // retry the exact same batch
+	REQUIRE(row_count(con, "t") == 2);
+	REQUIRE(scalar(con, "SELECT v FROM t WHERE id = 1") == "a");
+}
+
+TEST_CASE("MERGE folds a key re-sent in a later batch into the existing row", "[merge]") {
+	// Fivetran may re-send an already-synced record in a later sync. Since each
+	// file is a separate MERGE and the second one sees the first's committed
+	// rows, the re-sent key matches and updates rather than duplicating.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+
+	// batch 1
+	ok(con, "INSERT INTO staging VALUES (1, 'a')");
+	ok(con, UPSERT_MERGE);
+	// batch 2 re-sends key 1 (updated) and adds key 2
+	ok(con, "DELETE FROM staging");
+	ok(con, "INSERT INTO staging VALUES (1, 'a-updated'), (2, 'b')");
+	ok(con, UPSERT_MERGE);
+
+	REQUIRE(row_count(con, "t") == 2);
+	REQUIRE(scalar(con, "SELECT v FROM t WHERE id = 1") == "a-updated");
+}
+
+TEST_CASE("Without a constraint, a duplicate key within one MERGE batch is inserted twice", "[merge]") {
+	// This is the ONLY way MERGE can introduce a duplicate: two rows with the same
+	// key, both absent from the target, in a single batch. Fivetran de-duplicates
+	// within a sync, so this should not occur in practice; strict mode (next test)
+	// rejects it outright.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)"); // NOT NULL only, no key constraint
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 'x'), (1, 'y')"); // duplicate key, both new
+
+	ok(con, UPSERT_MERGE);
+
+	// Both source rows land under the same key: the target had no row for id=1,
+	// so neither source row matched, and each took the INSERT branch.
+	REQUIRE(row_count(con, "t") == 2);
+	REQUIRE(scalar(con, "SELECT count(*) FROM t WHERE id = 1") == "2");
+	REQUIRE(scalar(con, "SELECT string_agg(v, ',' ORDER BY v) FROM t WHERE id = 1") == "x,y");
+}
+
+TEST_CASE("A PRIMARY KEY constraint rejects a duplicate key within one MERGE batch", "[merge]") {
+	// Strict mode keeps the enforced PRIMARY KEY, so the duplicate-in-one-batch
+	// case above is rejected and rolled back rather than duplicated.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"id\" INTEGER PRIMARY KEY, \"v\" VARCHAR)");
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 'x'), (1, 'y')");
+
+	auto res = con.Query(UPSERT_MERGE);
+	REQUIRE(res->HasError()); // PRIMARY KEY / UNIQUE constraint violation
+	REQUIRE(row_count(con, "t") == 0);
+}
+
+TEST_CASE("MERGE does not error when several source rows match one target row", "[merge]") {
+	// DuckDB does not raise the SQL-standard "cardinality violation" here; it
+	// applies the updates and one value wins. The result is still a single row.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO t VALUES (1, 'orig')");
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 'a'), (1, 'b')");
+
+	ok(con, UPSERT_MERGE);
+
+	REQUIRE(row_count(con, "t") == 1);
+}
+
+TEST_CASE("MERGE matches on a composite key across all key columns", "[merge]") {
+	// The connector joins on every primary key column (ON k1=k1 AND k2=k2).
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	ok(con, "CREATE TABLE t (\"a\" INTEGER NOT NULL, \"b\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO t VALUES (1, 1, 'old')");
+	ok(con, "CREATE TABLE staging (\"a\" INTEGER, \"b\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 1, 'match'), (1, 2, 'different-b')");
+
+	ok(con, R"(
+	MERGE INTO t AS target USING staging AS source ON target."a" = source."a" AND target."b" = source."b"
+	  WHEN MATCHED THEN UPDATE SET "v" = source."v"
+	  WHEN NOT MATCHED THEN INSERT ("a", "b", "v") VALUES (source."a", source."b", source."v"))");
+
+	REQUIRE(row_count(con, "t") == 2);
+	REQUIRE(scalar(con, "SELECT v FROM t WHERE a = 1 AND b = 1") == "match");       // (1,1) matched -> updated
+	REQUIRE(scalar(con, "SELECT v FROM t WHERE a = 1 AND b = 2") == "different-b"); // (1,2) unmatched -> inserted
+}
+
+TEST_CASE("MdSqlGenerator::upsert produces a retry-safe MERGE (no PRIMARY KEY needed)", "[merge]") {
+	// End-to-end check of the connector's own generated SQL against in-memory
+	// DuckDB: it upserts correctly and stays idempotent on replay, without any
+	// key constraint on the target.
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+
+	auto logger = mdlog::Logger::CreateNopLogger();
+	MdSqlGenerator generator(logger);
+
+	std::vector<column_def> cols = {
+	    column_def {.name = "id", .type = duckdb::LogicalTypeId::INTEGER, .primary_key = true},
+	    column_def {.name = "v", .type = duckdb::LogicalTypeId::VARCHAR},
+	};
+	std::vector<const column_def*> columns_pk;
+	std::vector<const column_def*> columns_regular;
+	find_primary_keys(cols, columns_pk, &columns_regular);
+
+	const table_def table {"memory", "main", "t"};
+	ok(con, "CREATE TABLE \"memory\".\"main\".\"t\" (\"id\" INTEGER NOT NULL, \"v\" VARCHAR)");
+	ok(con, "CREATE TABLE staging (\"id\" INTEGER, \"v\" VARCHAR)");
+	ok(con, "INSERT INTO staging VALUES (1, 'a'), (2, 'b')");
+
+	generator.upsert(con, table, "staging", columns_pk, columns_regular);
+	REQUIRE(row_count(con, "\"memory\".\"main\".\"t\"") == 2);
+
+	// Replay the same staging rows: matched, not duplicated.
+	generator.upsert(con, table, "staging", columns_pk, columns_regular);
+	REQUIRE(row_count(con, "\"memory\".\"main\".\"t\"") == 2);
+
+	// New value for an existing key updates in place.
+	ok(con, "DELETE FROM staging");
+	ok(con, "INSERT INTO staging VALUES (1, 'a-updated'), (3, 'c')");
+	generator.upsert(con, table, "staging", columns_pk, columns_regular);
+	REQUIRE(row_count(con, "\"memory\".\"main\".\"t\"") == 3);
+	REQUIRE(scalar(con, "SELECT v FROM \"memory\".\"main\".\"t\" WHERE id = 1") == "a-updated");
+}


### PR DESCRIPTION
Updates the ALTER TABLE and INSERT behavior in the face of the new distinction between `PrimaryKeyMode::Strict` and `PrimaryKeyMode::NotNull`.

We want to make the enforcement of primary keys more lenient. We have two reasons for this:
- Ducklake doesn't support primary keys constraints, hence our Fivetran connector doesn't work with a Ducklake database
- Not all source connectors enforce uniqueness of primary key columns, and this would only become apparent during an insert or alter at our connector.

Instead of enforcing uniqueness of data in primary key columns, we offer the option to allow duplicates and only enforce non-nullness. Allowing non-unique data is the default.

The new `PrimaryKeyMode` affects three places:
1. Upserts are now done with `MERGE INTO` instead of `INSERT INTO ... ON CONFLICT`. The latter requires a primary key constraint to be defined on the merge columns, the former doesn't. Otherwise, it is equivalent.
2. In `create_table`, we add a `PRIMARY KEY` or only a `NOT NULL` constraint depending on the `PrimaryKeyMode`.
3. In `alter_table`, we have to refine the condition when to recreate a table. As before, if a PRIMARY KEY constraint is defined on a table and the primary key changes, we need to recreate the table. But in `PrimaryKeyMode::NotNull`, we can do primary key changes in-place because DuckDB's `ALTER TABLE` can do `SET NOT NULL` and `DROP NOT NULL`.

We recreate a table iff:
- we are in `PrimaryKeyMode::Strict` and the primary key has changed
- we are in `PrimaryKeyMode::Strict` and the table has no columns with PRIMARY KEY constraint (this implies that this is the first `alter_table` call after the user switched from NotNull to Strict mode recently)
- we are in `PrimaryKeyMode::NotNull` and the table has columns with PRIMARY KEY constraint (this implies that this is the first `alter_table` call after the user switched from Strict to NotNull mode recently)
Note that a) we only really enforce the new `PrimaryKeyMode` after the first `ALTER` statement, not directly when the configuration was changed and b) we recreate the table after the `PrimaryKeyMode` has changed even if the primary key itself didn't change.

