### PR TITLE
Explore: centralize OOM-to-task detection in the gRPC layer

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -21,20 +20,20 @@ void find_primary_keys(const std::vector<column_def>& cols, std::vector<const co
 /// surfaces to Fivetran as a task rather than a hard sync failure. This is a no-op for any other error type.
 void throw_recoverable_error_if_oom(const duckdb::ErrorData& error_data);
 
-/// If `result` has an error, throws it: out-of-memory errors become a md_error::RecoverableError (see
-/// throw_recoverable_error_if_oom), anything else becomes a std::runtime_error prefixed with `error_message`.
-/// This is the single place call sites should route through instead of hand-rolling their own
-/// HasError()/GetError() check, so new queries get OOM handling for free. Templated so it accepts both
-/// duckdb::BaseQueryResult (from Connection::Query) and duckdb::PreparedStatement (from Connection::Prepare),
-/// which share the same HasError()/GetError()/GetErrorObject() shape but do not share a base class. Takes
-/// `result` by non-const reference because PreparedStatement's GetError()/GetErrorObject() are not const.
+/// If `result` has an error, throws it via ErrorData::Throw(), which preserves the original
+/// duckdb::ExceptionType by JSON-encoding it into the resulting exception's what(). This is deliberate: it
+/// lets a single catch block far away (in motherduck_destination_server.cpp) reconstruct the ExceptionType
+/// later and decide whether the error is recoverable (e.g. out-of-memory), without every query call site
+/// needing to know or check that itself. Callers that want a plain, readable exception message should use
+/// extract_readable_error() on the caught exception rather than its what() directly.
+/// Templated so it accepts both duckdb::BaseQueryResult (from Connection::Query) and duckdb::PreparedStatement
+/// (from Connection::Prepare), which share the same HasError()/GetErrorObject() shape but do not share a base
+/// class. Takes `result` by non-const reference because PreparedStatement's GetErrorObject() is not const.
 template <typename T>
 void throw_if_query_error(T& result, const std::string& error_message) {
-	if (!result.HasError()) {
-		return;
+	if (result.HasError()) {
+		result.GetErrorObject().Throw(error_message + ": ");
 	}
-	throw_recoverable_error_if_oom(result.GetErrorObject());
-	throw std::runtime_error(error_message + ": " + result.GetError());
 }
 
 /// join() makes it easy to reduce a generic vector to a string with a specified pattern:

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -21,8 +21,56 @@
 #include <string>
 
 namespace {
+std::string extract_readable_error(const std::exception& ex) {
+	// DuckDB errors are JSON strings. Converting it to ErrorData to extract the
+	// message.
+	duckdb::ErrorData error(ex.what());
+	std::string error_message = error.RawMessage();
+
+	// Errors thrown in the initialization function are very verbose. Example:
+	// Invalid Input Error: Initialization function "motherduck_duckdb_cpp_init"
+	// from file "motherduck.duckdb_extension" threw an exception: "Failed to
+	// attach 'my_db': no database/share named 'my_db' found". We are only
+	// interested in the last part.
+	const std::string boilerplate = "Initialization function \"motherduck_";
+	if (error_message.find(boilerplate) != std::string::npos) {
+		const std::string search_string = "threw an exception: ";
+		const auto pos = error_message.find(search_string);
+		if (pos != std::string::npos) {
+			error_message = "Connection to MotherDuck failed: " + error_message.substr(pos + search_string.length());
+		}
+	}
+
+	const std::string not_found_error_substr = "no database/share named";
+	if (error_message.find(not_found_error_substr) != std::string::npos) {
+		// Remove the quotation mark at the end
+		error_message = error_message.substr(0, error_message.length() - 1);
+		// Full error: "no database/share named 'my_db' found. Create it first in
+		// your MotherDuck account."
+		error_message += ". Create it first in your MotherDuck account.\"";
+	}
+
+	return error_message;
+}
+
+// If `ex` carries a DuckDB out-of-memory ExceptionType (JSON-encoded into what() by
+// duckdb::ErrorData::Throw(), see throw_if_query_error), returns a friendly, actionable message for it.
+// Returns std::nullopt for any other exception, including non-DuckDB ones, so the caller can fall through to
+// its normal hard-failure handling. This is the single place that decides whether an error anywhere in
+// sql_generator.cpp/csv_processor.cpp should become a Fivetran task instead of a hard sync failure -- new
+// queries do not need to opt into this, they get it automatically as long as they throw through
+// throw_if_query_error (or otherwise preserve the DuckDB exception type through to here).
+std::optional<std::string> recoverable_oom_message(const std::exception& ex) {
+	try {
+		throw_recoverable_error_if_oom(duckdb::ErrorData(ex.what()));
+	} catch (const md_error::RecoverableError& mde) {
+		return std::string(mde.what());
+	}
+	return std::nullopt;
+}
+
 ::grpc::Status create_grpc_status_from_exception(const std::exception& ex, const std::string& prefix = "") {
-	const std::string error_message = md_error::truncate_for_grpc_header(ex.what());
+	const std::string error_message = md_error::truncate_for_grpc_header(extract_readable_error(ex));
 	// The assumption here is that the prefix is short enough that its length can
 	// be disregarded
 	return ::grpc::Status(::grpc::StatusCode::INTERNAL, prefix + error_message);
@@ -262,9 +310,16 @@ grpc::Status DestinationSdkImpl::DescribeTable(::grpc::ServerContext*,
 		response->mutable_task()->set_message(mde.what());
 		return ::grpc::Status::OK;
 	} catch (const std::exception& ex) {
+		if (const auto oom_message = recoverable_oom_message(ex)) {
+			logger.warning("DescribeTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
+			               request->table_name() + ">: " + *oom_message);
+			response->mutable_task()->set_message(*oom_message);
+			return ::grpc::Status::OK;
+		}
+		const std::string readable_message = extract_readable_error(ex);
 		logger.severe("DescribeTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
-		              request->table_name() + ">: " + std::string(ex.what()));
-		response->mutable_task()->set_message(ex.what());
+		              request->table_name() + ">: " + readable_message);
+		response->mutable_task()->set_message(readable_message);
 		return create_grpc_status_from_exception(ex);
 	}
 
@@ -299,9 +354,16 @@ grpc::Status DestinationSdkImpl::CreateTable(::grpc::ServerContext*,
 		response->mutable_task()->set_message(mde.what());
 		return ::grpc::Status::OK;
 	} catch (const std::exception& ex) {
+		if (const auto oom_message = recoverable_oom_message(ex)) {
+			logger.warning("CreateTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
+			               request->table().name() + ">: " + *oom_message);
+			response->mutable_task()->set_message(*oom_message);
+			return ::grpc::Status::OK;
+		}
+		const std::string readable_message = extract_readable_error(ex);
 		logger.severe("CreateTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
-		              request->table().name() + ">: " + std::string(ex.what()));
-		response->mutable_task()->set_message(ex.what());
+		              request->table().name() + ">: " + readable_message);
+		response->mutable_task()->set_message(readable_message);
 		return create_grpc_status_from_exception(ex);
 	}
 
@@ -333,9 +395,16 @@ grpc::Status DestinationSdkImpl::AlterTable(::grpc::ServerContext*,
 		response->mutable_task()->set_message(mde.what());
 		return ::grpc::Status::OK;
 	} catch (const std::exception& ex) {
+		if (const auto oom_message = recoverable_oom_message(ex)) {
+			logger.warning("AlterTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
+			               request->table().name() + ">: " + *oom_message);
+			response->mutable_task()->set_message(*oom_message);
+			return ::grpc::Status::OK;
+		}
+		const std::string readable_message = extract_readable_error(ex);
 		logger.severe("AlterTable endpoint failed for schema <" + request->schema_name() + ">, table <" +
-		              request->table().name() + ">: " + std::string(ex.what()));
-		response->mutable_task()->set_message(ex.what());
+		              request->table().name() + ">: " + readable_message);
+		response->mutable_task()->set_message(readable_message);
 		return create_grpc_status_from_exception(ex);
 	}
 
@@ -377,9 +446,16 @@ grpc::Status DestinationSdkImpl::Truncate(::grpc::ServerContext*, const ::fivetr
 		response->mutable_task()->set_message(mde.what());
 		return ::grpc::Status::OK;
 	} catch (const std::exception& ex) {
+		if (const auto oom_message = recoverable_oom_message(ex)) {
+			logger.warning("Truncate endpoint failed for schema <" + request->schema_name() + ">, table <" +
+			               request->table_name() + ">: " + *oom_message);
+			response->mutable_task()->set_message(*oom_message);
+			return ::grpc::Status::OK;
+		}
+		const std::string readable_message = extract_readable_error(ex);
 		logger.severe("Truncate endpoint failed for schema <" + request->schema_name() + ">, table <" +
-		              request->table_name() + ">: " + std::string(ex.what()));
-		response->mutable_task()->set_message(ex.what());
+		              request->table_name() + ">: " + readable_message);
+		response->mutable_task()->set_message(readable_message);
 		return create_grpc_status_from_exception(ex);
 	}
 
@@ -475,7 +551,13 @@ grpc::Status DestinationSdkImpl::WriteBatch(::grpc::ServerContext*,
 	} catch (const std::exception& ex) {
 		const std::string error_prefix = "WriteBatch endpoint failed for schema <" + request->schema_name() +
 		                                 ">, table <" + request->table().name() + ">: ";
-		const auto error_msg = error_prefix + ex.what();
+		if (const auto oom_message = recoverable_oom_message(ex)) {
+			const auto msg = error_prefix + *oom_message;
+			logger.warning(msg);
+			response->mutable_task()->set_message(msg);
+			return ::grpc::Status::OK;
+		}
+		const auto error_msg = error_prefix + extract_readable_error(ex);
 		logger.severe(error_msg);
 		response->mutable_task()->set_message(error_msg);
 		return create_grpc_status_from_exception(ex, error_prefix);
@@ -631,7 +713,19 @@ grpc::Status DestinationSdkImpl::WriteBatch(::grpc::ServerContext*,
 	} catch (const std::exception& ex) {
 		const std::string error_prefix = "WriteHistoryBatch endpoint failed for schema <" + request->schema_name() +
 		                                 ">, table <" + request->table().name() + ">: ";
-		const auto msg = error_prefix + ex.what();
+		if (const auto oom_message = recoverable_oom_message(ex)) {
+			const auto msg = error_prefix + *oom_message;
+			logger.warning(msg);
+
+			// Clean up bookkeeping table. The function uses IF EXISTS. Ignore any
+			// errors here.
+			sql_generator->drop_latest_active_records_table(con, lar_table_name);
+
+			response->mutable_task()->set_message(msg);
+			return ::grpc::Status::OK;
+		}
+
+		const auto msg = error_prefix + extract_readable_error(ex);
 		logger.severe(msg);
 
 		// Clean up bookkeeping table. The function uses IF EXISTS. Ignore any
@@ -643,38 +737,6 @@ grpc::Status DestinationSdkImpl::WriteBatch(::grpc::ServerContext*,
 	}
 
 	return ::grpc::Status::OK;
-}
-
-std::string extract_readable_error(const std::exception& ex) {
-	// DuckDB errors are JSON strings. Converting it to ErrorData to extract the
-	// message.
-	duckdb::ErrorData error(ex.what());
-	std::string error_message = error.RawMessage();
-
-	// Errors thrown in the initialization function are very verbose. Example:
-	// Invalid Input Error: Initialization function "motherduck_duckdb_cpp_init"
-	// from file "motherduck.duckdb_extension" threw an exception: "Failed to
-	// attach 'my_db': no database/share named 'my_db' found". We are only
-	// interested in the last part.
-	const std::string boilerplate = "Initialization function \"motherduck_";
-	if (error_message.find(boilerplate) != std::string::npos) {
-		const std::string search_string = "threw an exception: ";
-		const auto pos = error_message.find(search_string);
-		if (pos != std::string::npos) {
-			error_message = "Connection to MotherDuck failed: " + error_message.substr(pos + search_string.length());
-		}
-	}
-
-	const std::string not_found_error_substr = "no database/share named";
-	if (error_message.find(not_found_error_substr) != std::string::npos) {
-		// Remove the quotation mark at the end
-		error_message = error_message.substr(0, error_message.length() - 1);
-		// Full error: "no database/share named 'my_db' found. Create it first in
-		// your MotherDuck account."
-		error_message += ". Create it first in your MotherDuck account.\"";
-	}
-
-	return error_message;
 }
 
 std::string get_migration_schema_name(const fivetran_sdk::v2::MigrationDetails& details) {
@@ -924,10 +986,18 @@ grpc::Status DestinationSdkImpl::Migrate(::grpc::ServerContext*, const ::fivetra
 	} catch (const std::exception& e) {
 		const std::string schema = request->details().schema();
 		const std::string table = request->details().table();
+		if (const auto oom_message = recoverable_oom_message(e)) {
+			const std::string msg =
+			    "Migrate endpoint failed for schema <" + schema + ">, table <" + table + ">: " + *oom_message;
+			logger.warning(msg);
+			response->mutable_task()->set_message(msg);
+			return ::grpc::Status::OK;
+		}
+		const std::string readable_message = extract_readable_error(e);
 		logger.severe("Migrate endpoint failed for schema <" + schema + ">, table <" + table +
-		              ">: " + std::string(e.what()));
-		response->mutable_task()->set_message(e.what());
-		return ::grpc::Status(::grpc::StatusCode::INTERNAL, e.what());
+		              ">: " + readable_message);
+		response->mutable_task()->set_message(readable_message);
+		return ::grpc::Status(::grpc::StatusCode::INTERNAL, readable_message);
 	}
 
 	return ::grpc::Status(::grpc::StatusCode::OK, "");

--- a/test/test_sql_generator.cpp
+++ b/test/test_sql_generator.cpp
@@ -41,19 +41,32 @@ TEST_CASE("throw_if_query_error is a no-op for a successful result", "[sql_gener
 	REQUIRE_NOTHROW(throw_if_query_error(*result, "should not be thrown"));
 }
 
-TEST_CASE("throw_if_query_error wraps a regular error in a prefixed std::runtime_error", "[sql_generator]") {
+// NOTE: unlike the sibling branch, throw_if_query_error here does NOT decide whether an error is recoverable.
+// It always re-throws via duckdb::ErrorData::Throw(), which JSON-encodes the original ExceptionType into the
+// resulting exception's what(). The actual out-of-memory-to-task decision is made far away, in
+// motherduck_destination_server.cpp's recoverable_oom_message(), by reconstructing a duckdb::ErrorData from
+// what() and checking its Type(). These tests verify that round trip survives.
+
+TEST_CASE("throw_if_query_error preserves the exception type through what() for a regular error", "[sql_generator]") {
 	duckdb::DuckDB db(nullptr);
 	duckdb::Connection con(db);
 
 	const auto result = con.Query("SELECT * FROM nonexistent_table");
 	REQUIRE(result->HasError());
 
-	REQUIRE_THROWS_AS(throw_if_query_error(*result, "Could not query table"), std::runtime_error);
-	REQUIRE_THROWS_WITH(throw_if_query_error(*result, "Could not query table"),
-	                    Catch::Matchers::ContainsSubstring("Could not query table"));
+	bool threw = false;
+	try {
+		throw_if_query_error(*result, "Could not query table");
+	} catch (const std::exception& ex) {
+		threw = true;
+		const duckdb::ErrorData reconstructed(ex.what());
+		REQUIRE(reconstructed.Type() != duckdb::ExceptionType::OUT_OF_MEMORY);
+		REQUIRE_THAT(reconstructed.RawMessage(), Catch::Matchers::ContainsSubstring("Could not query table"));
+	}
+	REQUIRE(threw);
 }
 
-TEST_CASE("throw_if_query_error converts an out-of-memory error into a RecoverableError", "[sql_generator]") {
+TEST_CASE("throw_if_query_error preserves the out-of-memory exception type through what()", "[sql_generator]") {
 	duckdb::DuckDB db(nullptr);
 	duckdb::Connection con(db);
 	REQUIRE_NO_FAIL(con.Query("SET memory_limit='1MB'"));
@@ -62,5 +75,13 @@ TEST_CASE("throw_if_query_error converts an out-of-memory error into a Recoverab
 	REQUIRE(result->HasError());
 	REQUIRE(result->GetErrorObject().Type() == duckdb::ExceptionType::OUT_OF_MEMORY);
 
-	REQUIRE_THROWS_AS(throw_if_query_error(*result, "Could not create table"), md_error::RecoverableError);
+	bool threw = false;
+	try {
+		throw_if_query_error(*result, "Could not create table");
+	} catch (const std::exception& ex) {
+		threw = true;
+		const duckdb::ErrorData reconstructed(ex.what());
+		REQUIRE(reconstructed.Type() == duckdb::ExceptionType::OUT_OF_MEMORY);
+	}
+	REQUIRE(threw);
 }


### PR DESCRIPTION
## What this is

An exploration of [Donny's suggestion](https://github.com/motherduckdb/motherduck-fivetran-connector/pull/178#pullrequestreview-4991573597) on #178: instead of every query call site deciding for itself whether its error is a recoverable OOM, centralize that decision in `motherduck_destination_server.cpp`'s catch blocks, since those already wrap every endpoint's logic regardless of what queries get added to `sql_generator.cpp` in the future.

**Not intended to replace #178 as-is** — this is a working prototype to see the actual shape and cost of the idea, built on top of that branch.

## How it works

- `throw_if_query_error` no longer inspects the error at all. It always re-throws via `result.GetErrorObject().Throw(prefix)`, which JSON-encodes the original `duckdb::ExceptionType` into the thrown exception's `what()`.
- A new `recoverable_oom_message(ex)` helper in `motherduck_destination_server.cpp` reconstructs a `duckdb::ErrorData` from `ex.what()` and reuses the existing `throw_recoverable_error_if_oom` to decide if it's OOM.
- Every endpoint's generic `catch (const std::exception& ex)` arm now checks `recoverable_oom_message(ex)` before falling through to the hard-failure path.

The result: a brand new query added anywhere in `sql_generator.cpp`/`csv_processor.cpp` gets OOM-to-task handling automatically, as long as it throws through `throw_if_query_error` — no per-call-site awareness needed, which was the actual concern behind the review comment.

## The cost this surfaces

DuckDB's JSON-encoded `what()` isn't human-readable. Once `throw_if_query_error` always produces it, **every place that previously read `ex.what()` directly** — log lines, `response->mutable_task()->set_message(...)`, `create_grpc_status_from_exception(...)` — would leak raw JSON to the user or logs unless unwrapped first via `extract_readable_error()` (previously used only by the `Test` endpoint, for connection-time errors).

So this ended up touching all 7 write/migrate endpoints' generic catch arms, not just adding one check — the "don't need to touch every call site" premise mostly moves the touch points from `sql_generator.cpp` (many small query sites) to `motherduck_destination_server.cpp` (fewer but more surgical endpoint catch blocks). Whether that's a net win depends on how often new *queries* get added (sql_generator.cpp) vs. new *endpoints* (server.cpp) — in this codebase the former is far more common per git history, which is a point in favor of #178's current per-call-site approach, not this one.

Also worth noting: `extract_readable_error()`'s `duckdb::ErrorData` string constructor gracefully no-ops on non-JSON input (falls back to using the raw string), so applying it everywhere is safe even for non-DuckDB exceptions (`std::invalid_argument`, etc.) and doesn't regress any existing message.

## Testing

Updated `test/test_sql_generator.cpp`: `throw_if_query_error` no longer throws `md_error::RecoverableError` directly (that decision moved to the server), so its tests now verify the underlying mechanism this whole approach depends on — that the `ExceptionType` (including `OUT_OF_MEMORY`) survives being thrown as a generic `std::exception`, caught elsewhere, and reconstructed via `duckdb::ErrorData(ex.what())`.

No new test for `recoverable_oom_message()` itself — it's an anonymous-namespace function in `motherduck_destination_server.cpp`, and there's no existing precedent in this codebase for unit-testing that file's internal helpers (coverage there is via `test/integration/test_server.cpp`-style integration tests against a real gRPC server instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)