### PR TITLE
Logging for crash debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ link_dependencies(fivetran_sdk)
 add_library(motherduck_destination_sources STATIC
         src/config_tester.cpp
         src/connection_factory.cpp
+        src/crash_handler.cpp
         src/csv_processor.cpp
         src/decryption.cpp
         src/extension_helper.cpp

--- a/includes/crash_handler.hpp
+++ b/includes/crash_handler.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace crash_handler {
+
+// Installs handlers for the fatal signals (SIGSEGV, SIGABRT, ...)
+// and for orderly termination (SIGTERM, SIGINT).
+void Install();
+
+} // namespace crash_handler

--- a/includes/request_context.hpp
+++ b/includes/request_context.hpp
@@ -5,6 +5,7 @@
 #include "google/protobuf/map.h"
 #include "md_logging.hpp"
 
+#include <chrono>
 #include <string>
 
 /// Context for a single request to the MotherDuck destination server.
@@ -35,4 +36,5 @@ private:
 	duckdb::Connection con;
 	// Logger has to have a shorter lifetime than the connection
 	mdlog::Logger logger;
+	std::chrono::steady_clock::time_point started_at;
 };

--- a/src/connection_factory.cpp
+++ b/src/connection_factory.cpp
@@ -51,15 +51,14 @@ void enable_verbose_logging_for_user(duckdb::Connection& con, const mdlog::Logge
 		return;
 	}
 
-	const auto set_res =
-	    con.Query("SET motherduck_log_level='" + std::string(VERBOSE_LOG_LEVEL) + "'");
+	const auto set_res = con.Query("SET motherduck_log_level='" + std::string(VERBOSE_LOG_LEVEL) + "'");
 	if (set_res->HasError()) {
 		logger.warning("get_duckdb: could not raise the MotherDuck log level for user <" + user_id +
 		               ">: " + set_res->GetError());
 		return;
 	}
-	logger.info("get_duckdb: raised MotherDuck client logging to '" + std::string(VERBOSE_LOG_LEVEL) +
-	            "' for user <" + user_id + ">");
+	logger.info("get_duckdb: raised MotherDuck client logging to '" + std::string(VERBOSE_LOG_LEVEL) + "' for user <" +
+	            user_id + ">");
 }
 } // namespace
 

--- a/src/connection_factory.cpp
+++ b/src/connection_factory.cpp
@@ -29,6 +29,38 @@ void maybe_rewrite_error(const std::exception& ex, const std::string& db_name) {
 		                                 msg);
 	}
 }
+
+// Temporary, targeted diagnostics: raise MotherDuck client logging for a single
+// user while their connector crashes are under investigation. Remove once those are understood.
+constexpr const char* VERBOSE_LOGGING_USER_ID = "b8e29aae-1ee8-4e24-bb77-a61e15155589";
+constexpr const char* VERBOSE_LOG_LEVEL = "debug";
+
+void enable_verbose_logging_for_user(duckdb::Connection& con, const mdlog::Logger& logger) {
+	const auto user_res = con.Query("SELECT user_id FROM md_user_info()");
+	if (user_res->HasError()) {
+		logger.warning("get_duckdb: could not read the user id, leaving the log level unchanged: " +
+		               user_res->GetError());
+		return;
+	}
+	if (user_res->RowCount() == 0) {
+		return;
+	}
+
+	const auto user_id = user_res->GetValue(0, 0).ToString();
+	if (user_id != VERBOSE_LOGGING_USER_ID) {
+		return;
+	}
+
+	const auto set_res =
+	    con.Query("SET motherduck_log_level='" + std::string(VERBOSE_LOG_LEVEL) + "'");
+	if (set_res->HasError()) {
+		logger.warning("get_duckdb: could not raise the MotherDuck log level for user <" + user_id +
+		               ">: " + set_res->GetError());
+		return;
+	}
+	logger.info("get_duckdb: raised MotherDuck client logging to '" + std::string(VERBOSE_LOG_LEVEL) +
+	            "' for user <" + user_id + ">");
+}
 } // namespace
 
 duckdb::DuckDB& ConnectionFactory::get_duckdb(const std::string& md_auth_token, const std::string& db_name) {
@@ -63,6 +95,8 @@ duckdb::DuckDB& ConnectionFactory::get_duckdb(const std::string& md_auth_token, 
 		if (set_collation_res->HasError()) {
 			stdout_logger.severe("get_duckdb: Could not SET default_collation: " + set_collation_res->GetError());
 		}
+
+		enable_verbose_logging_for_user(con, stdout_logger);
 
 		initial_md_token = md_auth_token;
 		initial_db_name = db_name;

--- a/src/crash_handler.cpp
+++ b/src/crash_handler.cpp
@@ -1,0 +1,123 @@
+#include "crash_handler.hpp"
+
+#include <execinfo.h>
+#include <signal.h>
+#include <unistd.h>
+
+namespace crash_handler {
+
+namespace {
+
+// Everything a handler touches must be async-signal-safe: write(2) only, no
+// allocation and no formatting through the standard library.
+
+void write_all(const char* data, const size_t len) {
+	size_t written = 0;
+	while (written < len) {
+		const ssize_t n = write(STDERR_FILENO, data + written, len - written);
+		if (n <= 0) {
+			return;
+		}
+		written += static_cast<size_t>(n);
+	}
+}
+
+template <size_t N>
+void write_literal(const char (&literal)[N]) {
+	write_all(literal, N - 1);
+}
+
+void write_unsigned(unsigned long value) {
+	// Neither printf nor std::to_string may be used here, so the digits are
+	// produced by hand: written right-aligned into the buffer, then emitted from
+	// the first one. The do/while is what makes zero render as "0" rather than
+	// as nothing at all.
+	constexpr size_t BUFFER_SIZE = 24; // enough for any 64-bit value in decimal
+	char buffer[BUFFER_SIZE];
+	size_t offset = BUFFER_SIZE;
+	do {
+		buffer[--offset] = static_cast<char>('0' + (value % 10));
+		value /= 10;
+	} while (value > 0 && offset > 0);
+
+	write_all(buffer + offset, BUFFER_SIZE - offset);
+}
+
+// Pre-allocated so the handler needs no stack space for it, which also gives it
+// a chance of reporting a stack overflow (delivered as SIGSEGV).
+constexpr int MAX_DEPTH = 120;
+void* crash_callstack[MAX_DEPTH];
+
+void log_crash(const int sig) {
+	// Keep this banner byte-for-byte stable: existing log searches match on it.
+	write_literal("\n=== SIGSEGV or SIGABRT ===\n");
+	write_literal("signal=");
+	write_unsigned(static_cast<unsigned long>(sig));
+	write_literal("\nStack trace:\n");
+
+	// backtrace() and backtrace_symbols_fd() are not specified by POSIX as
+	// async-signal-safe and may allocate internally, but they are commonly used
+	// in crash handlers as a best-effort way to capture a stack trace. Install()
+	// warms them up so the first call is not made from here.
+	const int num_frames = backtrace(crash_callstack, MAX_DEPTH);
+
+	// Emitted before the symbols so that "the unwinder returned nothing" can be
+	// told apart from "the output was truncated".
+	write_literal("frames=");
+	write_unsigned(static_cast<unsigned long>(num_frames > 0 ? num_frames : 0));
+	write_literal("\n");
+
+	if (num_frames > 0) {
+		backtrace_symbols_fd(crash_callstack, num_frames, STDERR_FILENO);
+	}
+	write_literal("=== end of stack trace ===\n");
+
+	raise(sig);
+}
+
+// Without this, an orderly shutdown looks exactly like a crash in the logs:
+// silence, no banner. Reporting it means a death with neither banner is a
+// SIGKILL (OOM kill or forced stop).
+void log_termination(const int sig) {
+	write_literal("\n=== terminated by signal ");
+	write_unsigned(static_cast<unsigned long>(sig));
+	write_literal(" (orderly shutdown, not a crash) ===\n");
+
+	raise(sig);
+}
+
+// glibc loads libgcc_s.so on the first backtrace() call, which allocates and
+// takes the loader lock. Doing that for the first time inside a handler can
+// deadlock or fault, which produces a banner with no frames after it.
+void warm_up_backtrace() {
+	void* frame[1];
+	(void)backtrace(frame, 1);
+}
+
+} // namespace
+
+void Install() {
+	struct sigaction crash_action = {};
+	sigemptyset(&crash_action.sa_mask);
+	crash_action.sa_handler = log_crash;
+	// SA_RESETHAND resets the signal handler to the default. If log_crash itself segfaults, then the default handler
+	// (coredump) is triggered. SA_NODEFER makes sure that if log_crash itself segfaults, the process dies immediately
+	// instead of hanging until log_crash is finished.
+	crash_action.sa_flags = static_cast<int>(SA_RESETHAND | SA_NODEFER);
+	sigaction(SIGSEGV, &crash_action, nullptr);
+	sigaction(SIGABRT, &crash_action, nullptr);
+	sigaction(SIGBUS, &crash_action, nullptr);
+	sigaction(SIGILL, &crash_action, nullptr);
+	sigaction(SIGFPE, &crash_action, nullptr);
+
+	struct sigaction term_action = {};
+	sigemptyset(&term_action.sa_mask);
+	term_action.sa_handler = log_termination;
+	term_action.sa_flags = static_cast<int>(SA_RESETHAND | SA_NODEFER);
+	sigaction(SIGTERM, &term_action, nullptr);
+	sigaction(SIGINT, &term_action, nullptr);
+
+	warm_up_backtrace();
+}
+
+} // namespace crash_handler

--- a/src/motherduck_destination.cpp
+++ b/src/motherduck_destination.cpp
@@ -1,11 +1,9 @@
+#include "crash_handler.hpp"
 #include "extension_helper.hpp"
 #include "motherduck_destination_server.hpp"
 
-#include <execinfo.h>
 #include <grpcpp/grpcpp.h>
-#include <signal.h>
 #include <string>
-#include <unistd.h>
 
 void RunServer(const std::string& port) {
 	std::string server_address = "0.0.0.0:" + port;
@@ -23,31 +21,8 @@ void RunServer(const std::string& port) {
 	server->Wait();
 }
 
-void log_crash(const int sig) {
-	constexpr char msg[] = "\n=== SIGSEGV or SIGABRT ===\nStack trace:\n";
-	write(STDERR_FILENO, msg, sizeof(msg) - 1);
-
-	// backtrace() and backtrace_symbols_fd() are not specified by POSIX
-	// as async-signal-safe and may allocate internally, but they are commonly
-	// used in crash handlers as a best-effort way to capture a stack trace.
-	static constexpr int MAX_DEPTH = 120;
-	void* callstack[MAX_DEPTH];
-	const int num_frames = backtrace(callstack, MAX_DEPTH);
-	backtrace_symbols_fd(callstack, num_frames, STDERR_FILENO);
-
-	raise(sig);
-}
-
 int main(const int argc, char** argv) {
-	struct sigaction sa = {};
-	sigemptyset(&sa.sa_mask);
-	sa.sa_handler = log_crash;
-	// SA_RESETHAND resets the signal handler to the default. If log_crash itself segfaults, then the default handler
-	// (coredump) is triggered. SA_NODEFER makes sure that if log_crash itself segfaults, the process dies immediately
-	// instead of hanging until log_crash is finished.
-	sa.sa_flags = static_cast<int>(SA_RESETHAND | SA_NODEFER);
-	sigaction(SIGSEGV, &sa, nullptr);
-	sigaction(SIGABRT, &sa, nullptr);
+	crash_handler::Install();
 
 	std::string port = "50052";
 	for (auto i = 1; i < argc; i++) {

--- a/src/request_context.cpp
+++ b/src/request_context.cpp
@@ -21,11 +21,9 @@ mdlog::Logger get_logger_for_env(duckdb::Connection& con) {
 
 RequestContext::RequestContext(const std::string& endpoint_name_, ConnectionFactory& connection_factory,
                                const google::protobuf::Map<std::string, std::string>& request_config)
-    : endpoint_name(endpoint_name_),
-      db_name(config::find_property(request_config, config::PROP_DATABASE)),
+    : endpoint_name(endpoint_name_), db_name(config::find_property(request_config, config::PROP_DATABASE)),
       md_token(config::find_property(request_config, config::PROP_TOKEN)),
-      con(connection_factory.CreateConnection(md_token, db_name)),
-      logger(get_logger_for_env(con)),
+      con(connection_factory.CreateConnection(md_token, db_name)), logger(get_logger_for_env(con)),
       started_at(std::chrono::steady_clock::now()) {
 	logger.debug("Endpoint <" + endpoint_name + "> started");
 }

--- a/src/request_context.cpp
+++ b/src/request_context.cpp
@@ -16,6 +16,7 @@ mdlog::Logger get_logger_for_env(duckdb::Connection& con) {
 	}
 	return mdlog::Logger::CreateMultiSinkLogger(&con);
 }
+
 } // namespace
 
 RequestContext::RequestContext(const std::string& endpoint_name_, ConnectionFactory& connection_factory,
@@ -24,13 +25,27 @@ RequestContext::RequestContext(const std::string& endpoint_name_, ConnectionFact
       db_name(config::find_property(request_config, config::PROP_DATABASE)),
       md_token(config::find_property(request_config, config::PROP_TOKEN)),
       con(connection_factory.CreateConnection(md_token, db_name)),
-      logger(get_logger_for_env(con)) {
+      logger(get_logger_for_env(con)),
+      started_at(std::chrono::steady_clock::now()) {
 	logger.debug("Endpoint <" + endpoint_name + "> started");
 }
 
 RequestContext::~RequestContext() {
-	if (con.HasActiveTransaction() && !con.IsAutoCommit()) {
-		con.Rollback();
+	const auto elapsed_ms =
+	    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at).count();
+
+	// A destructor is implicitly noexcept, so anything thrown here terminates the
+	// process and is reported as a crash. Rollback goes through Query("ROLLBACK")
+	// and throws when the connection is no longer usable, which is a situation we need to handle.
+	try {
+		if (con.HasActiveTransaction() && !con.IsAutoCommit()) {
+			con.Rollback();
+		}
+	} catch (const std::exception& ex) {
+		logger.warning("Endpoint <" + endpoint_name + ">: rollback failed during cleanup: " + std::string(ex.what()));
+	} catch (...) {
+		logger.warning("Endpoint <" + endpoint_name + ">: rollback failed during cleanup with an unknown exception");
 	}
-	logger.debug("Endpoint <" + endpoint_name + "> completed");
+
+	logger.debug("Endpoint <" + endpoint_name + "> completed in " + std::to_string(elapsed_ms) + "ms");
 }

--- a/test/integration/test_migrate.cpp
+++ b/test/integration/test_migrate.cpp
@@ -297,10 +297,10 @@ TEST_CASE("Migrate - copy table", "[integration][migrate]") {
 		REQUIRE(res->RowCount() == 4); // The order is: id, data, value, amount
 
 		// duckdb::Value() creates a NULL value
-		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                                 // id
-		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});                       // data
+		check_row(res, 0, {duckdb::Value(), "PRI", "INTEGER"});                                  // id
+		check_row(res, 1, {duckdb::Value(), duckdb::Value(), "VARCHAR"});                        // data
 		check_row(res, 2, {"CAST(\'42\' AS DECIMAL(17, 4))", duckdb::Value(), "DECIMAL(17,4)"}); // value
-		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"});                 // amount
+		check_row(res, 3, {duckdb::Value(), duckdb::Value(), "DECIMAL(31,6)"});                  // amount
 	}
 
 	// Clean up


### PR DESCRIPTION
- Improved crash handler: Report the number of stack frames and add an `=== END ===` banner to see if there were no frames in the backtrace or if the logs were truncated. Furthermore, we call `backtrace` already at the start of the process to load the dynamic library `libgcc_s` eagerly, not when it might already be too late.
- Add termination handler that reports the signal. This helps to distinguish between a normal termination and the process getting killed (e.g. when consuming too much memory).
- Catch exceptions during rollback in `RequestContext` destructor. There can still be a `std::bad_alloc` during logging, but I think we can ignore this case.
- `RequestContext` destructor now also reports the elapsed time per request.
- Enable verbose MotherDuck logs for user whose connector is crashing.
- Ran `make format`.